### PR TITLE
Upgrade Docusaurus to 3.5

### DIFF
--- a/config.json
+++ b/config.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "16.x",
-      "branch": "master",
+      "branch": "branch/v16",
       "latest": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "pre-commit": "yarn lint-staged"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/plugin-content-docs": "^3.4.0",
-    "@docusaurus/plugin-debug": "^3.4.0",
-    "@docusaurus/plugin-sitemap": "^3.4.0",
-    "@docusaurus/theme-classic": "^3.4.0",
+    "@docusaurus/core": "^3.5.0",
+    "@docusaurus/plugin-content-docs": "^3.5.0",
+    "@docusaurus/plugin-debug": "^3.5.0",
+    "@docusaurus/plugin-sitemap": "^3.5.0",
+    "@docusaurus/theme-classic": "^3.5.0",
     "@inkeep/widgets": "^0.2.288",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.1",

--- a/src/components/Search/InkeepSearch.tsx
+++ b/src/components/Search/InkeepSearch.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import { useDocsVersion } from "@docusaurus/theme-common/internal";
+import { useDocsVersion } from "@docusaurus/plugin-content-docs/client";
 import {
   type InkeepAIChatSettings,
   type InkeepSearchSettings,

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import { useWindowSize } from "@docusaurus/theme-common";
-import { useDoc } from "@docusaurus/theme-common/internal";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import DocItemPaginator from "@theme/DocItem/Paginator";
 import DocVersionBanner from "@theme/DocVersionBanner";
 import DocVersionBadge from "@theme/DocVersionBadge";
@@ -10,7 +10,7 @@ import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
 import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
 import DocItemContent from "@theme/DocItem/Content";
 import DocBreadcrumbs from "@theme/DocBreadcrumbs";
-import Unlisted from "@theme/Unlisted";
+import Unlisted from "@theme/ContentVisibility/Unlisted";
 import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
 import type { Props } from "@theme/DocItem/Layout";
 

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { HtmlClassNameProvider } from "@docusaurus/theme-common";
-import { DocProvider } from "@docusaurus/theme-common/internal";
+import { DocProvider } from "@docusaurus/plugin-content-docs/client";
 import DocItemMetadata from "@theme/DocItem/Metadata";
 import DocItemLayout from "@theme/DocItem/Layout";
 import type { Props } from "@theme/DocItem";

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -9,10 +9,8 @@ import {
   type GlobalVersion,
 } from "@docusaurus/plugin-content-docs/client";
 import { ThemeClassNames } from "@docusaurus/theme-common";
-import {
-  useDocsPreferredVersion,
-  useDocsVersion,
-} from "@docusaurus/theme-common/internal";
+import { useDocsPreferredVersion } from "@docusaurus/theme-common/internal";
+import { useDocsVersion } from "@docusaurus/plugin-content-docs/client";
 import type { Props } from "@theme/DocVersionBanner";
 import type {
   VersionBanner,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,7 +1351,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@docusaurus/core@3.5.2", "@docusaurus/core@^3.4.0":
+"@docusaurus/core@3.5.2", "@docusaurus/core@^3.5.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.5.2.tgz#3adedb90e7b6104592f1231043bd6bf91680c39c"
   integrity sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==
@@ -1525,7 +1525,7 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.5.2", "@docusaurus/plugin-content-docs@^3.4.0":
+"@docusaurus/plugin-content-docs@3.5.2", "@docusaurus/plugin-content-docs@^3.5.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.2.tgz#adcf6c0bd9a9818eb192ab831e0069ee62d31505"
   integrity sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==
@@ -1562,7 +1562,7 @@
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-debug@^3.4.0":
+"@docusaurus/plugin-debug@^3.5.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.5.2.tgz#c25ca6a59e62a17c797b367173fe80c06fdf2f65"
   integrity sha512-kBK6GlN0itCkrmHuCS6aX1wmoWc5wpd5KJlqQ1FyrF0cLDnvsYSnh7+ftdwzt7G6lGBho8lrVwkkL9/iQvaSOA==
@@ -1574,7 +1574,7 @@
     react-json-view-lite "^1.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-sitemap@^3.4.0":
+"@docusaurus/plugin-sitemap@^3.5.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.2.tgz#9c940b27f3461c54d65295cf4c52cb20538bd360"
   integrity sha512-DnlqYyRAdQ4NHY28TfHuVk414ft2uruP4QWCH//jzpHjqvKyXjj2fmDtI8RPUBh9K8iZKFMHRnLtzJKySPWvFA==
@@ -1589,7 +1589,7 @@
     sitemap "^7.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/theme-classic@^3.4.0":
+"@docusaurus/theme-classic@^3.5.0":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.5.2.tgz#602ddb63d987ab1f939e3760c67bc1880f01c000"
   integrity sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==
@@ -5794,9 +5794,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.41:
-  version "1.5.43"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.43.tgz#d9e69fc709ddebd521416de9d17cdef81d2d4718"
-  integrity sha512-NxnmFBHDl5Sachd2P46O7UJiMaMHMLSofoIWVJq3mj8NJgG0umiSeljAVP9lGzjI0UDLJJ5jjoGjcrB8RSbjLQ==
+  version "1.5.45"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.45.tgz#fa592ce6a88b44d23acbc7453a2feab98996e6c9"
+  integrity sha512-vOzZS6uZwhhbkZbcRyiy99Wg+pYFV5hk+5YaECvx0+Z31NR3Tt5zS6dze2OepT6PCTzVzT0dIJItti+uAW5zmw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
- Upgrade Docusaurus packages to `^3.5.0`
- Fix `@theme/Unlisted` import, since the module declaration was changed in https://github.com/facebook/docusaurus/pull/10376.
- Update imports to reflect the movement of some exports from `@docusaurus/theme-common/internal` into `@docusaurus/plugin-content-docs/client`. See https://github.com/facebook/docusaurus/pull/10316.