### PR TITLE
Documentation website build fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,19 +2,15 @@
 	path = content/14.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v14
-	shallow = true
 [submodule "content/15.x"]
 	path = content/15.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v15
-	shallow = true
 [submodule "content/16.x"]
 	path = content/16.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v16
-	shallow = true
 [submodule "content/17.x"]
 	path = content/17.x
 	url = https://github.com/gravitational/teleport/
 	branch = master
-	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,15 +2,19 @@
 	path = content/14.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v14
+	shallow = true
 [submodule "content/15.x"]
 	path = content/15.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v15
+	shallow = true
 [submodule "content/16.x"]
 	path = content/16.x
 	url = https://github.com/gravitational/teleport/
 	branch = branch/v16
+	shallow = true
 [submodule "content/17.x"]
 	path = content/17.x
 	url = https://github.com/gravitational/teleport/
 	branch = master
+	shallow = true

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -101,8 +101,8 @@ const config: Config = {
 
   title: "Teleport",
   favicon: "/favicon.ico",
-  url: "https://goteleport.com",
-  baseUrl: "/",
+  url: process.env.DOCUSAURUS_CONFIG_URL || "https://goteleport.com",
+  baseUrl: process.env.DOCUSAURUS_CONFIG_BASE_URL || "/",
 
   markdown: {
     parseFrontMatter: async (params) => {
@@ -126,7 +126,6 @@ const config: Config = {
     defaultLocale: "en",
     locales: ["en"],
   },
-
   plugins: [
     [
       "@docusaurus/plugin-client-redirects",
@@ -146,6 +145,10 @@ const config: Config = {
     [
       "@docusaurus/plugin-content-docs",
       {
+        // Host docs on the root page, later it will be exposed on goteleport.com/docs 
+        // next to the website and blog
+        // https://docusaurus.io/docs/docs-introduction#docs-only-mode
+        routeBasePath: "/",
         sidebarPath: "./sidebars.json",
         lastVersion: latestVersion,
         versions: getDocusaurusConfigVersionOptions(),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare-sanity-data": "npx vite-node ./scripts/prepare-sanity-data.mts",
     "docusaurus": "docusaurus",
     "start": "yarn prepare-files && yarn prepare-sanity-data && docusaurus start",
-    "build": "yarn git-update && yarn prepare-files && yarn prepare-sanity-data && docusaurus build",
+    "build": "yarn git-update && yarn prepare-files && yarn prepare-sanity-data && docusaurus build \"$@\"",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "spellcheck": "bash scripts/check-spelling.sh",
-    "git-update": "git submodule update --init --remote --progress --depth 1",
+    "git-update": "git submodule update --init --remote --progress --depth 1 --single-branch",
     "prepare-files": "npx vite-node ./scripts/prepare-files.mts",
     "prepare-sanity-data": "npx vite-node ./scripts/prepare-sanity-data.mts",
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "spellcheck": "bash scripts/check-spelling.sh",
-    "git-update": "git submodule update --init --remote --progress --recommend-shallow",
+    "git-update": "git submodule update --init --remote --progress --depth 1",
     "prepare-files": "npx vite-node ./scripts/prepare-files.mts",
     "prepare-sanity-data": "npx vite-node ./scripts/prepare-sanity-data.mts",
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "spellcheck": "bash scripts/check-spelling.sh",
-    "git-update": "git submodule update --init --remote --progress",
+    "git-update": "git submodule update --init --remote --progress --recommend-shallow",
     "prepare-files": "npx vite-node ./scripts/prepare-files.mts",
     "prepare-sanity-data": "npx vite-node ./scripts/prepare-sanity-data.mts",
     "docusaurus": "docusaurus",

--- a/server/redirects.ts
+++ b/server/redirects.ts
@@ -29,8 +29,8 @@ export const getRedirects = () => {
     }
 
     return {
-      from: `/docs${redirect.source}`,
-      to: `/docs${redirect.destination}`,
+      from: redirect.source,
+      to: redirect.destination,
     };
   });
 };


### PR DESCRIPTION
### Summary

Bunch of update to improve documentation website deployment:

1. Configure submodules as shallow for quicker build
2. Expose env variables `DOCUSAURUS_CONFIG_URL` and `DOCUSAURUS_CONFIG_BASE_URL` to allow dynamic configuration
3. Configure `routeBasePath` to `/` as per https://docusaurus.io/docs/docs-introduction#docs-only-mode
4. Update `yarn build` command to expose CLI params, to be able to use `--out-build` as per:
   - https://github.com/facebook/docusaurus/issues/2404#issuecomment-856161542
5. Remove hardcoded `docs` prefix from redirect urls