### PR TITLE
Throw an exception on broken MD links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -25,6 +25,7 @@ import { extendedPostcssConfigPlugin } from "./server/postcss";
 const latestVersion = getLatestVersion();
 
 const config: Config = {
+  onBrokenMarkdownLinks: "throw",
   customFields: {
     innkeepConfig: {
       apiKey: process.env.INKEEP_API_KEY,
@@ -145,7 +146,7 @@ const config: Config = {
     [
       "@docusaurus/plugin-content-docs",
       {
-        // Host docs on the root page, later it will be exposed on goteleport.com/docs 
+        // Host docs on the root page, later it will be exposed on goteleport.com/docs
         // next to the website and blog
         // https://docusaurus.io/docs/docs-introduction#docs-only-mode
         routeBasePath: "/",


### PR DESCRIPTION
The default is to print a warning when a Markdown link is unresolved, meaning that docs builds can succeed with links that cause 404s.