### PR TITLE
Reconfigure the favicon

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -101,7 +101,7 @@ const config: Config = {
   },
 
   title: "Teleport",
-  favicon: "/favicon.ico",
+  favicon: "/favicon.svg",
   url: process.env.DOCUSAURUS_CONFIG_URL || "https://goteleport.com",
   baseUrl: process.env.DOCUSAURUS_CONFIG_BASE_URL || "/",
 


### PR DESCRIPTION
Closes #5

In the Docusaurus config file, replace `favicon.ico` with `favicon.svg`, which has a transparent background.