### PR TITLE
Add Var component support

### DIFF
--- a/server/rehype-hljs.ts
+++ b/server/rehype-hljs.ts
@@ -24,23 +24,18 @@ export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
     // We only visit text nodes inside code snippets that include either the
     // <Var tag or (if we have already swapped out Vars with placeholders) a
     // placeholder.
-    const isVarContainer = (node: Node) => {
+    const isPossibleVarContainer = (node: Node) => {
       let textValue;
-      if (node.type === "text") {
-        textValue = node.value;
-      } else if (
-        node.type === "element" &&
-        node.children.length === 1 &&
-        node.children[0].type === "text"
+      if (
+        node.type === "text" ||
+        (node.type === "element" &&
+          node.children.length === 1 &&
+          node.children[0].type === "text")
       ) {
-        textValue = node.children[0].value;
+        return true;
       } else {
         return false;
       }
-
-      const placeHolderRE = new RegExp(placeholderPattern);
-
-      return textValue.includes("<Var") || placeHolderRE.test(textValue);
     };
 
     // Highlight common languages in addition to any additional configured ones.
@@ -58,35 +53,39 @@ export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
     // In a code snippet, Var elements are parsed as text. Replace these with
     // UUID strings to ensure that the parser won't split these up and make
     // them unrecoverable.
-    visit(root, isVarContainer, (node: Node, index: number, parent: Parent) => {
-      const varPattern = new RegExp("<Var [^>]+/>", "g");
-      let txt: Text;
-      if (node.type == "text") {
-        txt = node;
-      } else {
-        // isVarContainer enforces having a single child text node
-        txt = node.children[0];
-      }
+    visit(
+      root,
+      isPossibleVarContainer,
+      (node: Node, index: number, parent: Parent) => {
+        const varPattern = new RegExp("<Var [^>]+/>", "g");
+        let txt: Text;
+        if (node.type == "text") {
+          txt = node;
+        } else {
+          // isPossibleVarContainer enforces having a single child text node
+          txt = node.children[0];
+        }
 
-      const newVal = txt.value.replace(varPattern, (match) => {
-        const placeholder = makePlaceholder();
-        // Since the Var element was originally text, parse it so we can recover
-        // its properties. The result should be a small HTML AST with a root
-        // node and one child, the Var node.
-        const varElement = unified()
-          .use(remarkParse)
-          .use(remarkMDX)
-          .parse(match);
+        const newVal = txt.value.replace(varPattern, (match) => {
+          const placeholder = makePlaceholder();
+          // Since the Var element was originally text, parse it so we can recover
+          // its properties. The result should be a small HTML AST with a root
+          // node and one child, the Var node.
+          const varElement = unified()
+            .use(remarkParse)
+            .use(remarkMDX)
+            .parse(match);
 
-        placeholdersToVars[placeholder] = varElement.children[0];
-        return placeholder;
-      });
-      if (node.type == "text") {
-        node.value = newVal;
-      } else {
-        node.children[0].value = newVal;
+          placeholdersToVars[placeholder] = varElement.children[0];
+          return placeholder;
+        });
+        if (node.type == "text") {
+          node.value = newVal;
+        } else {
+          node.children[0].value = newVal;
+        }
       }
-    });
+    );
 
     // Apply syntax highlighting
     (highlighter as Function)(root, file);
@@ -95,91 +94,95 @@ export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
     // series of span elements with different "hljs-*" classes. Find the
     // placeholder UUIDs and replace them with their original Var elements,
     // inserting these as HTML AST nodes.
-    visit(root, isVarContainer, (node: Node, index: number, parent: Parent) => {
-      const el = node as Element | Text;
-      let hljsSpanValue = "";
-      if (el.type === "text") {
-        hljsSpanValue = el.value;
-      } else {
-        hljsSpanValue = (el.children[0] as Text).value;
-      }
-
-      // This is either a text node or an hljs span with only the placeholder as
-      // its child. We don't need the node, so replace it with the original
-      // Var.
-      if (placeholdersToVars[hljsSpanValue]) {
-        (parent as any).children[index] = placeholdersToVars[hljsSpanValue];
-        return [CONTINUE];
-      }
-
-      const placeholders = Array.from(
-        hljsSpanValue.matchAll(new RegExp(placeholderPattern, "g"))
-      );
-
-      // No placeholders to recover, so there's nothing more to do.
-      if (placeholders.length == 0) {
-        return [CONTINUE];
-      }
-
-      // The element's text includes one or more Vars among other content, so we
-      // need to replace the span (or text node) with a series of spans (or
-      // text nodes) separated by Vars.
-      let newChildren: Array<Text | Element> = [];
-
-      // Assemble a map of indexes to their corresponding placeholders so we
-      // can tell whether a given index falls within a placeholder.
-      const placeholderIndices = new Map();
-      placeholders.forEach((p) => {
-        placeholderIndices.set(p.index, p[0]);
-      });
-
-      let valueIdx = 0;
-      while (valueIdx < hljsSpanValue.length) {
-        // The current index is in a placeholder, so add the original Var
-        // component to newChildren.
-        if (placeholderIndices.has(valueIdx)) {
-          const placeholder = placeholderIndices.get(valueIdx);
-          valueIdx += placeholder.length;
-          newChildren.push(placeholdersToVars[placeholder] as Element);
-          continue;
-        }
-        // The current index is outside a placeholder, so assemble a text or
-        // span node and push that to newChildren.
-        let textVal = "";
-        while (
-          !placeholderIndices.has(valueIdx) &&
-          valueIdx < hljsSpanValue.length
-        ) {
-          textVal += hljsSpanValue[valueIdx];
-          valueIdx++;
-        }
+    visit(
+      root,
+      isPossibleVarContainer,
+      (node: Node, index: number, parent: Parent) => {
+        const el = node as Element | Text;
+        let hljsSpanValue = "";
         if (el.type === "text") {
-          newChildren.push({
-            type: "text",
-            value: textVal,
-          });
+          hljsSpanValue = el.value;
         } else {
-          newChildren.push({
-            tagName: "span",
-            type: "element",
-            properties: el.properties,
-            children: [
-              {
-                type: "text",
-                value: textVal,
-              },
-            ],
-          });
+          hljsSpanValue = (el.children[0] as Text).value;
         }
-      }
 
-      // Delete the current span and replace it with the new children.
-      (parent.children as Array<Text | Element>).splice(
-        index,
-        1,
-        ...newChildren
-      );
-      return [SKIP, index + newChildren.length];
-    });
+        // This is either a text node or an hljs span with only the placeholder as
+        // its child. We don't need the node, so replace it with the original
+        // Var.
+        if (placeholdersToVars[hljsSpanValue]) {
+          (parent as any).children[index] = placeholdersToVars[hljsSpanValue];
+          return [CONTINUE];
+        }
+
+        const placeholders = Array.from(
+          hljsSpanValue.matchAll(new RegExp(placeholderPattern, "g"))
+        );
+
+        // No placeholders to recover, so there's nothing more to do.
+        if (placeholders.length == 0) {
+          return [CONTINUE];
+        }
+
+        // The element's text includes one or more Vars among other content, so we
+        // need to replace the span (or text node) with a series of spans (or
+        // text nodes) separated by Vars.
+        let newChildren: Array<Text | Element> = [];
+
+        // Assemble a map of indexes to their corresponding placeholders so we
+        // can tell whether a given index falls within a placeholder.
+        const placeholderIndices = new Map();
+        placeholders.forEach((p) => {
+          placeholderIndices.set(p.index, p[0]);
+        });
+
+        let valueIdx = 0;
+        while (valueIdx < hljsSpanValue.length) {
+          // The current index is in a placeholder, so add the original Var
+          // component to newChildren.
+          if (placeholderIndices.has(valueIdx)) {
+            const placeholder = placeholderIndices.get(valueIdx);
+            valueIdx += placeholder.length;
+            newChildren.push(placeholdersToVars[placeholder] as Element);
+            continue;
+          }
+          // The current index is outside a placeholder, so assemble a text or
+          // span node and push that to newChildren.
+          let textVal = "";
+          while (
+            !placeholderIndices.has(valueIdx) &&
+            valueIdx < hljsSpanValue.length
+          ) {
+            textVal += hljsSpanValue[valueIdx];
+            valueIdx++;
+          }
+          if (el.type === "text") {
+            newChildren.push({
+              type: "text",
+              value: textVal,
+            });
+          } else {
+            newChildren.push({
+              tagName: "span",
+              type: "element",
+              properties: el.properties,
+              children: [
+                {
+                  type: "text",
+                  value: textVal,
+                },
+              ],
+            });
+          }
+        }
+
+        // Delete the current span and replace it with the new children.
+        (parent.children as Array<Text | Element>).splice(
+          index,
+          1,
+          ...newChildren
+        );
+        return [SKIP, index + newChildren.length];
+      }
+    );
   };
 };

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -54,7 +54,7 @@ const getVariableNode = (
 
   return {
     type: "mdxJsxFlowElement",
-    name: "var",
+    name: "Var",
     attributes: [
       { type: "mdxJsxAttribute", name: "name", value },
       {

--- a/server/remark-update-tags.ts
+++ b/server/remark-update-tags.ts
@@ -108,40 +108,6 @@ export default function remarkMigrationUpdateTags(): Transformer {
         return index; // index of the next element to traverse, in this case repeat the same index again
       }
 
-      // Replace Var with uppercase content
-      if (isMdxNode(node) && node.name.toLowerCase() === "var") {
-        parent.children[index] = {
-          type: "text",
-          value:
-            getAttributeValue(node, "initial") ||
-            getAttributeValue(node, "name"),
-        } as MdastText;
-      }
-
-      // Replace Var in clode blocks
-      if (isCodeNode(node)) {
-        const regexNode = /(\<\s*[vV]ar\s+(.*?)\s*\/\>)/g;
-        const regexProperty = /([a-z]+)\s*=\s*"([^"]*?)"/gi;
-
-        node.value = node.value.replaceAll(regexNode, (match) => {
-          const propsHash = Array.from(match.matchAll(regexProperty)).reduce(
-            (result, value) => {
-              return { ...result, [value[1]]: value[2] };
-            },
-            {} as { initial: string; name: string }
-          );
-
-          return propsHash.initial || propsHash.name;
-        });
-      }
-
-      // Remove "code" code type
-      if (isCodeNode(node)) {
-        if (node.lang === "code") {
-          node.lang = "bash";
-        }
-      }
-
       // Remove string styles from nodes
       if (isMdxNode(node)) {
         node.attributes = node.attributes.filter(

--- a/src/components/Variables/Var.module.css
+++ b/src/components/Variables/Var.module.css
@@ -1,0 +1,57 @@
+.field,
+.fake-field {
+  box-sizing: border-box;
+  width: 100%;
+  margin-left: var(--m-1);
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+.field {
+  z-index: 1;
+  padding: var(--m-0-5) var(--m-3) var(--m-0-5) var(--m-0-5);
+  font-family: var(--font-monospace);
+  font-size: var(--fs-text-md);
+  color: var(--color-light-blue);
+  border: 1px solid transparent;
+  border-radius: var(--r-default);
+  cursor: pointer;
+
+  &:focus {
+    border-color: var(--color-light-gray);
+    outline: none;
+  }
+}
+
+.fake-field {
+  overflow: hidden;
+  padding-right: var(--m-3);
+  padding-left: var(--m-0-5);
+  border-right: 1px solid transparent;
+  border-left: 1px solid transparent;
+  opacity: 0;
+  white-space: nowrap;
+}
+
+.wrapper,
+.label {
+  position: relative;
+  display: inline-grid;
+  align-items: baseline;
+  margin-right: var(--m-1-5);
+}
+
+.label .field,
+.label .fake-field {
+  grid-area: 1 / 2 / 1 / 3;
+}
+
+.icon {
+  position: absolute;
+  top: 50%;
+  right: -3px;
+  z-index: 2;
+  width: 16px;
+  height: 16px;
+  color: var(--color-light-blue);
+  transform: translateY(-50%);
+}

--- a/src/components/Variables/Var.tsx
+++ b/src/components/Variables/Var.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import cn from "classnames";
+import { useContext } from "react";
+import Icon from "/src/components/Icon";
+import { VarsContext } from "./context";
+import type { VarsContextProps } from "./context";
+import styles from "./Var.module.css";
+
+interface VarProps {
+  name?: string;
+  description?: string;
+  needLabel?: boolean;
+  isGlobal?: boolean;
+  initial?: string;
+}
+
+export const Var = ({
+  name,
+  description = "",
+  needLabel = false,
+  isGlobal = false,
+  initial = "",
+}: VarProps) => {
+  const { fields, initials, putField, setInitial } =
+    useContext<VarsContextProps>(VarsContext);
+  let defaultVal = initial;
+  const val = fields[name] || initials[name] || initial || "";
+
+  const onChange = (event) => {
+    putField(name, event.target.value, isGlobal, description);
+  };
+
+  // Update VarsContext after the Var renders. Once VarsContext re-renders, it
+  // also re-renders the rest of the DOM with the variable's initial value.
+  // The dependency array after the useEffect callback prevents an infinite
+  // render loop.
+  //
+  // This is not the intended purpose of useEffect, so we should eventually find
+  // a better way to do this.
+  useEffect(() => {
+    if (!initials[name] && initial) {
+      setInitial(name, initial);
+    }
+  }, [name, initial, initials, setInitial]);
+
+  const input = (
+    <>
+      <input
+        data-testid="var-input"
+        className={styles.field}
+        type="text"
+        size={val.length || name.length}
+        name={name}
+        placeholder={name}
+        onChange={onChange}
+        value={val}
+      />
+      <span className={styles["fake-field"]}>{val || name}</span>
+      <Icon name="edit" className={styles.icon} />
+    </>
+  );
+
+  const label = description ? description : name;
+
+  if (needLabel) {
+    return (
+      <label className={styles.label}>
+        {label}:{input}
+      </label>
+    );
+  }
+
+  return <span className={cn("wrapper-input", styles.wrapper)}>{input}</span>;
+};

--- a/src/components/Variables/context.tsx
+++ b/src/components/Variables/context.tsx
@@ -1,0 +1,99 @@
+import { createContext, useCallback, useMemo, useState } from "react";
+
+export interface VarsContextProps {
+  fields: {
+    [name: string]: string;
+  };
+  globalFields: {
+    [name: string]: boolean;
+  };
+  initials: {
+    [name: string]: string;
+  };
+  fieldDescriptions: {
+    [name: string]: string;
+  };
+  putField: (
+    name: string,
+    value: string,
+    isGlobal?: boolean,
+    description?: string
+  ) => void;
+  setInitial: (name: string, initial: string) => void;
+}
+
+export const VarsContext = createContext<VarsContextProps>({
+  fields: {},
+  globalFields: {},
+  initials: {},
+  fieldDescriptions: {},
+  putField: () => {},
+  setInitial: () => {},
+});
+
+interface VarsProviderProps {
+  children: React.ReactNode;
+}
+
+const getName = (rawName: string) => `global_var_${rawName}`;
+
+const saveValue = (rawName: string, value: string): boolean => {
+  const name = getName(rawName);
+  try {
+    sessionStorage.setItem(name, value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const getValue = (rawName: string): string | undefined => {
+  const name = getName(rawName);
+  try {
+    return sessionStorage.getItem(name) || "";
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const VarsProvider = ({ children }: VarsProviderProps) => {
+  const [fields, setFields] = useState({});
+  const [globalFields, setGlobalFields] = useState({});
+  const [fieldDescriptions, setFieldDescriptions] = useState({});
+  const [initials, setInitials] = useState({});
+
+  // putField is provided to context consumers. Since it calls state setter
+  // functions (via useState, above), each call triggers a rerender of
+  // VarsProvider, providing up-to-date values to context consumers.
+  const putField = (name, value, isGlobal, description) => {
+    if (description) {
+      setFieldDescriptions((d) => ({ ...d, [name]: description }));
+    }
+
+    if (isGlobal) {
+      setGlobalFields((f) => ({ ...f, [name]: true }));
+    }
+
+    setFields((f) => ({ ...f, [name]: value }));
+
+    if (globalFields[name]) {
+      saveValue(name, value);
+    }
+  };
+
+  const setInitial = (name: string, initial: string) => {
+    setInitials((i) => ({ ...i, [name]: initial }));
+    setFields((f) => ({ ...f, [name]: initial }));
+  };
+
+  const value = {
+    fields,
+    globalFields,
+    fieldDescriptions,
+    initials,
+    putField,
+    setInitial,
+  };
+
+  return <VarsContext.Provider value={value}>{children}</VarsContext.Provider>;
+};

--- a/src/components/Variables/index.ts
+++ b/src/components/Variables/index.ts
@@ -1,0 +1,2 @@
+export { Var } from "./Var";
+export { VarsProvider } from "./context";

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -15,7 +15,7 @@ import MDXImg from "@theme/MDXComponents/Img";
 import Mermaid from "@theme/Mermaid";
 import Command, { CommandLine, CommandComment } from "/src/components/Command";
 import Snippet from "/src/components/Snippet";
-
+import { Var } from "/src/components/Variables";
 import type { MDXComponentsObject } from "@theme/MDXComponents";
 
 const MDXComponents: MDXComponentsObject = {
@@ -44,6 +44,7 @@ const MDXComponents: MDXComponentsObject = {
   pre: MDXPre,
   snippet: Snippet,
   ul: MDXUl,
+  Var: (props) => <Var {...props} />, // needed to circumvent props mismatch in types
 };
 
 export default MDXComponents;

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { VarsProvider } from "/src/components/Variables";
+
+// Root is the root of a Docusaurus site. Manually swizzled to add context
+// providers. See:
+// https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root
+export default function Root({ children }) {
+  return <VarsProvider>{children}</VarsProvider>;
+}


### PR DESCRIPTION
Closes #14
Closes #6

Copy the `Var` component `VarsProvider` context provider from `gravitational/docs` and adapt them to the Docusaurus site. Edit the `remark-update-tags` to not remove `Var` components before building the docs site.

Fix the visitor test function in `rehype-hljs`. Check for `Var` placeholders as well as `Var` tags, since otherwise the test won't work in the second `visit` call.