### PR TITLE
Add a trailing slash to docs pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -36,10 +36,10 @@ const config: Config = {
   },
   customFields: {
     inkeepConfig: {
-        apiKey: getFromSecretOrEnv("INKEEP_API_KEY"),
-        integrationId: getFromSecretOrEnv("INKEEP_INTEGRATION_ID"),
-        organizationId: getFromSecretOrEnv("INKEEP_ORGANIZATION_ID"),
-      }
+      apiKey: getFromSecretOrEnv("INKEEP_API_KEY"),
+      integrationId: getFromSecretOrEnv("INKEEP_INTEGRATION_ID"),
+      organizationId: getFromSecretOrEnv("INKEEP_ORGANIZATION_ID"),
+    },
   },
   clientModules: [
     "./src/styles/variables.css",
@@ -112,6 +112,10 @@ const config: Config = {
   favicon: "/favicon.svg",
   url: process.env.DOCUSAURUS_CONFIG_URL || "https://goteleport.com",
   baseUrl: process.env.DOCUSAURUS_CONFIG_BASE_URL || "/",
+  // Our hosting infrastructure redirects requests to a docs page that do not
+  // contain a trailing slash in the URL, so add trailing slashes to sitemap
+  // URLs to prevent clients from receiving non-200 responses.
+  trailingSlash: true,
 
   markdown: {
     parseFrontMatter: async (params) => {


### PR DESCRIPTION
Our hosting infrastructure redirects URLs without a trailing slash to URLs with one, causing URLs from the sitemap to return non-200 responses to clients. This damages the SEO of the docs site.