### PR TITLE
Ensure upcoming releases page is synchronized across branches

### DIFF
--- a/scripts/prepare-files.mts
+++ b/scripts/prepare-files.mts
@@ -4,6 +4,7 @@ import { glob } from "glob";
 import { docusaurusifyNavigation } from "../server/config-docs";
 import {
   getCurrentVersion,
+  getLatestVersion,
   getVersionNames,
   getDocusaurusVersions,
 } from "../server/config-site";
@@ -17,6 +18,7 @@ const GET_VERSION_SIDEBAR_FILENAME = (version) =>
 
 const docusaurusVersions = getDocusaurusVersions();
 const currentVersion = getCurrentVersion();
+const defaultVersion = getLatestVersion();
 const versions = getVersionNames();
 
 const writeSidebar = (version: string) => {
@@ -66,3 +68,14 @@ versions.forEach((version) => {
 });
 
 writeVersions();
+
+// Make sure the upcoming releases page is the same on all 3 branches.
+const versionsToOverride = getVersionNames().filter(v => v !== defaultVersion);
+const defaultUpcomingReleases = resolve("content", defaultVersion, "docs/pages/upcoming-releases.mdx");
+versionsToOverride.forEach((version) => {
+  const destination = version === currentVersion
+    ? resolve("docs", "upcoming-releases.mdx")
+    : resolve(DOCS_PAGES_ROOT, `version-${version}`, "upcoming-releases.mdx");
+
+  copyFileSync(defaultUpcomingReleases, destination);
+})


### PR DESCRIPTION
We only update one version of `docs/pages/upcoming-release.mdx` at a time, as this isn't really a "versioned" page. We only use this page to communicate what's coming in the next set of releases and when to expect them.

As a result, consumers of our docs have a poor experience. If they're looking at the correct version of the docs, they see accurate and up to date info, but if they're on any other version, they see old, outdated, and inapplicable info.

We solve this by copying the default version of upcoming-releases.mdx to all other branches prior to deployment, ensuring that readers see the same content no matter which version is selected in the version selector.
