### PR TITLE
Change the default docs version

### DIFF
--- a/config.json
+++ b/config.json
@@ -71,12 +71,12 @@
     },
     {
       "name": "16.x",
-      "branch": "branch/v16",
-      "isDefault": true
+      "branch": "branch/v16"
     },
     {
       "name": "17.x",
-      "branch": "branch/v17"
+      "branch": "branch/v17",
+      "isDefault": true
     },
     {
       "name": "18.x",


### PR DESCRIPTION
Update the default docs version to v17 to coincide with the rollout to Cloud customers.