### PR TITLE
Downgrading google analytics package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@docusaurus/faster": "^3.6.3",
     "@docusaurus/plugin-content-docs": "^3.6.3",
     "@docusaurus/plugin-debug": "^3.6.3",
-    "@docusaurus/plugin-google-gtag": "^3.7.0",
+    "@docusaurus/plugin-google-gtag": "^3.6.3",
     "@docusaurus/plugin-sitemap": "^3.6.3",
     "@docusaurus/theme-classic": "^3.6.3",
     "@inkeep/widgets": "^0.2.288",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,9 +2144,9 @@
     react-json-view-lite "^1.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-gtag@^3.7.0":
+"@docusaurus/plugin-google-gtag@^3.6.3":
   version "3.7.0"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.7.0.tgz#a48638dfd132858060458b875a440b6cbda6bf8f"
   integrity sha512-M3vrMct1tY65ModbyeDaMoA+fNJTSPe5qmchhAbtqhDD/iALri0g9LrEpIOwNaoLmm6lO88sfBUADQrSRSGSWA==
   dependencies:
     "@docusaurus/core" "3.7.0"


### PR DESCRIPTION
Currently the build fails due to a mismatch in versions
```
  [cause]: Error: Invalid name=docusaurus-plugin-google-gtag version number=3.7.0.
  All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.6.3).
  Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```

This downgrades the version to match the other `@docusaurus/*` package versions.