### PR TITLE
Edit the `yarn git-update` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "spellcheck": "bash scripts/check-spelling.sh",
     "build-remark": "rm -rf .remark-build && tsc --build tsconfig.node.json && tsc-esm-fix --target='.remark-build' --ext='.mjs'",
-    "git-update": "git submodule update --init --remote --progress --depth 1 --single-branch",
+    "git-update": "scripts/update_submodules.sh",
     "prepare-files": "npx vite-node ./scripts/prepare-files.mts",
     "prepare-sanity-data": "npx vite-node ./scripts/prepare-sanity-data.mts",
     "docusaurus": "docusaurus",

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fetch all submodule refs on a local machine. On the AWS Amplify build runner,
+# only execute a shallow fetch with a single branch.
+if [[ -n ${AWS_APP_ID} ]]; then
+    git submodule update --init --remote --progress --depth 1 --single-branch
+else
+    git submodule update --init --remote --progress
+fi


### PR DESCRIPTION
Only execute a shallow/single-branch submodule fetch if running the script on the AWS Amplify build runner. Otherwise, fetch all submodules refs to help with local development.