### PR TITLE
Rename preview job name to match required check name

### DIFF
--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -8,7 +8,6 @@ permissions:
 
 jobs:
   amplify-preview:
-    name: Prepare Amplify Preview
     runs-on: ubuntu-22.04-2core-arm64
     environment: docs-amplify
     steps:

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -1,4 +1,4 @@
-name: Amplify Preview
+name: Docs Preview
 on:
   pull_request:
 
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   amplify-preview:
+    name: Amplify Preview
     runs-on: ubuntu-22.04-2core-arm64
     environment: docs-amplify
     steps:


### PR DESCRIPTION
### Summary

We've configured required GHA Status check to be `Amplify Preview`.
However this seems to be checking against Job name rather than Workflow name.

Hence, rename check from `Amplify Preview / Prepare Amplify Preview` to `Docs Preview / Amplify Preview`

- https://github.com/gravitational/docs-website/issues/104