### PR TITLE
Add retry logic on git submodule loads

### DIFF
--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -2,8 +2,22 @@
 
 # Fetch all submodule refs on a local machine. On the AWS Amplify build runner,
 # only execute a shallow fetch with a single branch.
-if [[ -n ${AWS_APP_ID} ]]; then
-    git submodule update --init --remote --progress --depth 1 --single-branch
-else
-    git submodule update --init --remote --progress
-fi
+function fetch_submodules () {
+  if [[ -n ${AWS_APP_ID} ]]; then
+      return $(git submodule update --init --remote --progress --depth 1 --single-branch)
+  else
+      return $(git submodule update --init --remote --progress)
+  fi
+}
+
+let "i=0";
+let "s=0";
+while [ ${i} -lt 5 ]; do
+    fetch_submodules && exit 0;
+    let "i++";
+    let "s=s+5";
+    echo "Failed to load submodules. Trying again in ${s}s."
+    sleep ${s};
+done;
+
+exit 1;

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -4,9 +4,9 @@
 # only execute a shallow fetch with a single branch.
 function fetch_submodules () {
   if [[ -n ${AWS_APP_ID} ]]; then
-      return $(git submodule update --init --remote --progress --depth 1 --single-branch)
+      git submodule update --init --remote --progress --depth 1 --single-branch
   else
-      return $(git submodule update --init --remote --progress)
+      git submodule update --init --remote --progress
   fi
 }
 


### PR DESCRIPTION
Sometimes a transient network error prevents git submodule loads from succeeding while building the docs site. Edit the `update_submodules.sh` script to add rudimentary retry logic. If `git submodule update` fails, retry the command for up to five attempts, with the time between retries increasing by five seconds each time.

This change introduces this approach because it is not possible to configure HTTP request retries in the git config, nor is there a curl environment variable we can set to enable retries in git's `https://` transport.