### PR TITLE
Use more reasonable sidebar ordering logic

### DIFF
--- a/server/sidebar-order.test.ts
+++ b/server/sidebar-order.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, test } from "@jest/globals";
+import { basename, dirname } from "node:path";
+import { orderSidebarItems } from "./sidebar-order";
+import type { docPage } from "./sidebar-order";
+import type { NormalizedSidebarItem } from "@docusaurus/plugin-content-docs/src/sidebars/types.ts";
+
+// makeDocPageMap takes a page ID and creates the docs page metadata that would
+// have generated a sidebar item, letting us simplify tests. The page title comes
+// from the ID of the page, with hyphens replaced by spaces and the first word
+// capitalized. Other attributes are taken from page IDs as well.
+function getDocPageForId(id: string): docPage {
+  let title = basename(id).replaceAll("-", " ");
+  title = title[0].toUpperCase() + title.slice(1);
+
+  return {
+    title: title,
+    id: id,
+    frontmatter: {
+      title: title,
+      description: "Provides information on Teleport functionality",
+    },
+    source: "@site/docs/" + id + ".mdx",
+    sourceDirName: dirname(id),
+  };
+}
+
+describe.only("orderSidebarItems", () => {
+  interface testCase {
+    description: string;
+    input: Array<NormalizedSidebarItem>;
+    expected: Array<NormalizedSidebarItem>;
+  }
+
+  // To write a test case, you can print the items array returned by
+  // defaultSidebarItemsGenerator in docusaurus.config.ts and find the
+  // subarray of items you would like to include.
+  const testCases: Array<testCase> = [
+    {
+      description: "Orders docs pages alphabetically by title",
+      input: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/page-c",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-a",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-b",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/page-a",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-b",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-c",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      description: "Places introduction pages first",
+      input: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/page-b",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-a",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-introduction",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/page-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-a",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/page-b",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      description: "Places getting started after introduction",
+      input: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      description: "alphabetizes introduction  and getting started pages",
+      input: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/b-getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a-getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/c-introduction",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/a-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/c-introduction",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a-getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-getting-started",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      description: "get started and getting started",
+      input: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/b-get-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/a-getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-getting-started",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "My Docs Category",
+          items: [
+            {
+              type: "doc",
+              id: "reference/my-category/a-getting-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-get-started",
+            },
+            {
+              type: "doc",
+              id: "reference/my-category/b-getting-started",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      description: "a mix of categories and pages",
+      input: [
+        {
+          type: "category",
+          label: "Applications",
+          items: [
+            {
+              type: "category",
+              label: "Securing Access to Cloud APIs",
+              items: [
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/aws-console",
+                },
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+              },
+            },
+            {
+              type: "doc",
+              id: "enroll-resources/application-access/application-access-controls",
+            },
+            {
+              type: "doc",
+              id: "enroll-resources/application-access/getting-started",
+            },
+            {
+              type: "category",
+              label: "Application Access Guides",
+              items: [
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/amazon-athena",
+                },
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/api-access",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "enroll-resources/application-access/guides/guides",
+              },
+            },
+          ],
+          link: {
+            type: "doc",
+            id: "enroll-resources/application-access/application-access",
+          },
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "Applications",
+          items: [
+            {
+              type: "doc",
+              id: "enroll-resources/application-access/getting-started",
+            },
+            {
+              type: "doc",
+              id: "enroll-resources/application-access/application-access-controls",
+            },
+            {
+              type: "category",
+              label: "Application Access Guides",
+              items: [
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/amazon-athena",
+                },
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/api-access",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "enroll-resources/application-access/guides/guides",
+              },
+            },
+            {
+              type: "category",
+              label: "Securing Access to Cloud APIs",
+              items: [
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/aws-console",
+                },
+                {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+              },
+            },
+          ],
+          link: {
+            type: "doc",
+            id: "enroll-resources/application-access/application-access",
+          },
+        },
+      ],
+    },
+    {
+      description: "nested category",
+      input: [
+        {
+          type: "category",
+          label: "Category A",
+          items: [
+            {
+              type: "category",
+              label: "Category B",
+              items: [
+                {
+                  type: "doc",
+                  id: "category-a/category-b/page-b",
+                },
+                {
+                  type: "doc",
+                  id: "category-a/category-b/page-a",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "category-a/category-b/category-b",
+              },
+            },
+            {
+              type: "category",
+              label: "Category C",
+              items: [
+                {
+                  type: "doc",
+                  id: "category-a/category-b/category-c/page-b",
+                },
+                {
+                  type: "doc",
+                  id: "category-a/category-b/category-c/page-a",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "category-a/category-b/category-b/category-c/category-c",
+              },
+            },
+            {
+              type: "doc",
+              id: "category-a/page-a",
+            },
+          ],
+          link: {
+            type: "doc",
+            id: "category-a/category-a",
+          },
+        },
+      ],
+      expected: [
+        {
+          type: "category",
+          label: "Category A",
+          items: [
+            {
+              type: "category",
+              label: "Category B",
+              items: [
+                {
+                  type: "doc",
+                  id: "category-a/category-b/page-a",
+                },
+                {
+                  type: "doc",
+                  id: "category-a/category-b/page-b",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "category-a/category-b/category-b",
+              },
+            },
+            {
+              type: "category",
+              label: "Category C",
+              items: [
+                {
+                  type: "doc",
+                  id: "category-a/category-b/category-c/page-a",
+                },
+                {
+                  type: "doc",
+                  id: "category-a/category-b/category-c/page-b",
+                },
+              ],
+              link: {
+                type: "doc",
+                id: "category-a/category-b/category-b/category-c/category-c",
+              },
+            },
+            {
+              type: "doc",
+              id: "category-a/page-a",
+            },
+          ],
+          link: {
+            type: "doc",
+            id: "category-a/category-a",
+          },
+        },
+      ],
+    },
+  ];
+
+  test.each(testCases)("$description", (c) => {
+    const actual = orderSidebarItems(c.input, getDocPageForId);
+    expect(actual).toEqual(c.expected);
+  });
+});

--- a/server/sidebar-order.ts
+++ b/server/sidebar-order.ts
@@ -1,0 +1,105 @@
+import type {
+  NormalizedSidebarItem,
+  SidebarItemDoc,
+  NormalizedSidebarItemCategory,
+} from "@docusaurus/plugin-content-docs/src/sidebars/types.ts";
+import type { PropVersionDoc } from "@docusaurus/plugin-content-docs";
+
+export interface docPage {
+  title: string;
+  id: string;
+  frontmatter: {
+    [index: string]: any;
+  };
+  source: string;
+  sourceDirName: string;
+  sideBarPosition?: number;
+}
+
+interface titleFeatures {
+  title: string;
+  isIntroduction: boolean;
+  isGettingStarted: boolean;
+}
+
+// getTitleFeatures extracts attributes of a NormalizedSidebarItem's title (or
+// label, in the case of category pages) for sorting. Titles are lowercased.
+const getTitleFeatures = (
+  item: NormalizedSidebarItem,
+  getter: (id: string) => docPage
+): titleFeatures => {
+  let title: string;
+  switch (item.type) {
+    case "doc":
+      title = getter((item as SidebarItemDoc).id).title;
+      break;
+    case "category":
+      if (!(item as NormalizedSidebarItemCategory).label) {
+        return undefined;
+      }
+      title = item.label;
+      break;
+    default:
+      return undefined;
+  }
+
+  return {
+    title: title.toLowerCase(),
+    isIntroduction: title.toLowerCase().includes("introduction"),
+    isGettingStarted: title.toLowerCase().match(/get(ting)? started/) !== null,
+  };
+};
+
+export const orderSidebarItems = (
+  items: Array<NormalizedSidebarItem>,
+  getter: (id: string) => docPage
+): Array<NormalizedSidebarItem> => {
+  const newItems = [];
+
+  // Start by recursively descending into items and sorting their children.
+  items.forEach((item) => {
+    let newItem = Object.assign({}, item);
+    const cat = newItem as NormalizedSidebarItemCategory;
+    if (cat.items) {
+      cat.items = orderSidebarItems(cat.items, getter);
+      newItems.push(cat);
+      return;
+    }
+    newItems.push(item);
+  });
+
+  return newItems.sort((a, b) => {
+    const aTitle = getTitleFeatures(a, getter);
+    const bTitle = getTitleFeatures(b, getter);
+
+    // We can't sort by title, so don't compare.
+    if (aTitle == undefined || bTitle == undefined) {
+      return 0;
+    }
+
+    // Sort pages first if they include "introduction" (case-insensitive) in
+    // the title.
+    if (aTitle.isIntroduction && !bTitle.isIntroduction) {
+      return -1;
+    }
+    if (bTitle.isIntroduction && !aTitle.isIntroduction) {
+      return 1;
+    }
+
+    // Sort pages earlier if they are getting started guides.
+    if (aTitle.isGettingStarted && !bTitle.isGettingStarted) {
+      return -1;
+    }
+    if (bTitle.isGettingStarted && !aTitle.isGettingStarted) {
+      return 1;
+    }
+
+    // If there's nothing special about one title relative to the other,
+    // sort them alphabetically.
+    if (aTitle.title >= bTitle.title) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
+};


### PR DESCRIPTION
Closes gravitational/teleport#51030
Closes gravitational/teleport#47231

The Docusaurus sidebar generator currently orders guides within a sidebar section by slug, which makes sidebar labels appear out of order. Instead, apply the following logic, which places page labels in the sidebar in positions where users would expect to find them:

- Labels that include "introduction" appear first
- Labels that include "get started" or "getting started" appear next
- After that, labels in a sidebar section appear in alphabeitcal order

This change adds a function that modifies the order of the sidebar items returned by the default Docusaurus sidebar generation function.