### PR TITLE
Reconfigure table sizing

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,3 +37,29 @@ body {
     display: block;
   }
 }
+
+article {
+  /* Support mobile devices without scaling if a component exceeds the article
+     * width, e.g., for tables 
+    */
+  overflow-x: scroll;
+}
+
+/* For tables, use a fixed table layout so a page that features multiple tables
+ * with the same columns can display all columns with the same alignment.
+ * Specify both a cell width and a table width so the columns are always
+ * aligned. If there are fewer than three cells per row, use a wider cell.
+ If there are more than three cells per row, use a narrower cell */
+table {
+  table-layout: fixed;
+  width: 675px;
+  max-width: 675px;
+}
+
+table:not(table:has(td:nth-of-type(3))) td {
+  width: 300px;
+}
+
+table:has(td:nth-of-type(3)) td {
+  width: 150px;
+}


### PR DESCRIPTION
Docs pages often include multiple tables with the same headings. For examples, see the following pages:

- `/faq`
- `/admin-guides/access-controls/compliance-frameworks/fedramp/`

With the current CSS, it is difficult for a reader to follow multiple instances of the same table from the top of a page to the bottom, since the columns in each instance have different widths. Since the docs engine's Markdown parser renders Markdown tables as rows and cells, instead of columns, we need to edit table cell sizing instead of column sizing.

Edit the styling for tables so that columns are aligned between multiple tables. Use the `fixed` `table-layout` property, with a fixed width for tables and cells based on a reasonable viewport width. Also set table cell width manually so the browser doesn't set this separately for each table. Use different width values for tables with three or more cells in each row and tables with fewer than three cells in each row.

To prevent the fixed-sized tables from scaling a page down on mobile, set the `overflow-x` property of `article` to `scroll`.