### PR TITLE
Remove Admonition logic from remark-update-tags

### DIFF
--- a/server/remark-update-tags.ts
+++ b/server/remark-update-tags.ts
@@ -62,29 +62,6 @@ export default function remarkMigrationUpdateTags(): Transformer {
         return index; // to traverse children
       }
 
-      // Notice and Admonition
-      if (isMdxNode(node) && node.name === "Notice") {
-        node.name = "Admonition";
-      }
-
-      if (isMdxNode(node) && node.name === "Admonition") {
-        const type = getAttribute(node, "type");
-
-        if (!type) {
-          node.attributes.push({
-            type: "mdxJsxAttribute",
-            name: "type",
-            value: "info",
-          });
-        } else {
-          type.value = (type.value as string).toLowerCase();
-
-          if (type.value === "notice") {
-            type.value = "note";
-          }
-        }
-      }
-
       // Unwrap Component
       if (
         isMdxNode(node) &&


### PR DESCRIPTION
Closes #94

The Admonition-related changes in `remark-update-tags` are already present in the docs, so there is no longer a need to perform this transformation.