### PR TITLE
Bump @inkeep to patch security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@docusaurus/plugin-svgr": "^3.7.0",
     "@docusaurus/theme-classic": "^3.7.0",
     "@docusaurus/tsconfig": "^3.7.0",
-    "@inkeep/widgets": "^0.2.290",
+    "@inkeep/widgets": "^0.2.292",
     "@mdx-js/react": "^3.0.0",
     "classnames": "^2.3.1",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,72 +2793,67 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@inkeep/color-mode@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.npmjs.org/@inkeep/color-mode/-/color-mode-0.0.24.tgz"
-  integrity sha512-P/ZqGqeKsSuVRk7vk2tucGZlmadY4XlrCF/BalFTdZ/i6CtRIrXaQWy1723/GVYabzvPAbzhZ89PI3YWXGL4Rw==
+"@inkeep/color-mode@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@inkeep/color-mode/-/color-mode-0.0.26.tgz#7c4aaea0ef7273a7afa3eb168e1dc500222ff794"
+  integrity sha512-zONJxr2NnAMeg8ohSWfd7qXbdOKJUaWRQAXYSTKwDTU4IEfeXNk5Y4rje4pQKlT0Nmi+qeiWbJilYZb3aHFKGA==
 
-"@inkeep/components@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.npmjs.org/@inkeep/components/-/components-0.0.24.tgz"
-  integrity sha512-n10+DXRSyq0K/GgUQ4+vbWEbWyE7YyhhQ9jq3YI8ST8BwAm0mDfFodE8nAGbHrvT9c4Hjzp2l5s7WS99oqr5eg==
+"@inkeep/components@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@inkeep/components/-/components-0.0.26.tgz#47048ef47b05ddc38f11bfae1cc1afd5255f04e7"
+  integrity sha512-0PqYSMvSkD/b4fV4FeoJj3AAZkREiAkJoICIIr7x4YaZYelDuJwcCane0TCKR9xMQt+CkwgTlvw5wi5K4003pQ==
   dependencies:
     "@ark-ui/react" "^0.15.0"
-    "@inkeep/preset" "^0.0.24"
-    "@inkeep/preset-chakra" "^0.0.24"
-    "@inkeep/shared" "^0.0.25"
-    "@inkeep/styled-system" "^0.0.44"
+    "@inkeep/preset" "^0.0.26"
+    "@inkeep/preset-chakra" "^0.0.26"
+    "@inkeep/shared" "^0.0.27"
+    "@inkeep/styled-system" "^0.0.48"
     "@pandacss/dev" "^0.22.0"
     framer-motion "^10.16.1"
 
-"@inkeep/preset-chakra@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.npmjs.org/@inkeep/preset-chakra/-/preset-chakra-0.0.24.tgz"
-  integrity sha512-kHzJunsKULuT2QrNnrzVdBrFR986LmO+YWZ4XAe5mRBxlNl+ODNyVZ/xWLC4xUcMnRlnVHHUhfIv9lYTrAR2fg==
+"@inkeep/preset-chakra@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@inkeep/preset-chakra/-/preset-chakra-0.0.26.tgz#5b79aa82a7d608da052d4fe4911f3a9c76a730e2"
+  integrity sha512-XOmi7/KAkLNUI2KxjReVIm74ku8ZhWCvVccvxqzPKBdTaNCdNn3cDaQomnjkOXEyhRYOkynX0451qjyn3iIS1Q==
   dependencies:
     "@ark-ui/anatomy" "^0.1.0"
-    "@inkeep/shared" "^0.0.25"
+    "@inkeep/shared" "^0.0.27"
     "@pandacss/dev" "^0.22.0"
 
-"@inkeep/preset@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.npmjs.org/@inkeep/preset/-/preset-0.0.24.tgz"
-  integrity sha512-9pcnBejUz+gh9IrZLfEQye5hJDRUCOKvrcRzlwpypnx8dFWpUYaTNg+Ja3ySoj3yzr5Keuu/5ZRxzy1WF1CLQg==
+"@inkeep/preset@^0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@inkeep/preset/-/preset-0.0.26.tgz#ec9a64679b4f12575c95c10c1c00ae1971867518"
+  integrity sha512-pIyMIKBIE3uMMBMSycv06prNqn80Y4dU+bV1KJBTv7skRxwo3t9It+ll+zIBBRUrBOMIEpBEQ1hAJnTb8ILuMg==
   dependencies:
     "@ark-ui/anatomy" "^0.1.0"
-    "@inkeep/preset-chakra" "^0.0.24"
-    "@inkeep/shared" "^0.0.25"
+    "@inkeep/preset-chakra" "^0.0.26"
+    "@inkeep/shared" "^0.0.27"
     "@pandacss/dev" "^0.22.0"
     colorjs.io "^0.4.5"
 
-"@inkeep/shared@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.npmjs.org/@inkeep/shared/-/shared-0.0.25.tgz"
-  integrity sha512-O4+vIgH12vwnMtD5RIv4y6jrKZTuIXFm7e7TkHtZTWNBRL8jPQuY73URbKCxaaGrcOY9XKKp+J4RZe5Wac07ug==
+"@inkeep/shared@^0.0.27":
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/@inkeep/shared/-/shared-0.0.27.tgz#5005ab604cbf91cc26c731f51a297387202c7937"
+  integrity sha512-1tRc+vsAsB4cJRKQNncrSu2tckPaLHYZB7YDYhNpROcM1SjegjoZc9NiWFtDCeHloHjYPA5E9gdzc+mbzyf5KQ==
 
-"@inkeep/styled-system@^0.0.44":
-  version "0.0.44"
-  resolved "https://registry.npmjs.org/@inkeep/styled-system/-/styled-system-0.0.44.tgz"
-  integrity sha512-dz2OjHGUD4C4ass6Rdzor0lmN1siYjFiboRMR9N7ACtVKbDgN6SYfNnb57K47jykIPFjhDNClg95R7x7ldDlpw==
+"@inkeep/styled-system@^0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@inkeep/styled-system/-/styled-system-0.0.48.tgz#df3d09afc9bf4b011d24158092f9b2dc8b2876d1"
+  integrity sha512-m0vklHzWS972T8lmVc1ue5EZcELUYgtWofzWC//Q1Q/DjD2Kn7j87DUEgzNdnBNRvQpHtYwD7HfjoVwAuZrKbA==
 
-"@inkeep/styled-system@^0.0.46":
-  version "0.0.46"
-  resolved "https://registry.npmjs.org/@inkeep/styled-system/-/styled-system-0.0.46.tgz"
-  integrity sha512-nL3jywgLkiDPTbIgi195AEgw7W/JvLGw5FDqTVI+o28syjgqvEohCSSpiIBDYkUEoz1XRZDImva1jNg17qzfXw==
-
-"@inkeep/widgets@^0.2.290":
-  version "0.2.290"
-  resolved "https://registry.yarnpkg.com/@inkeep/widgets/-/widgets-0.2.290.tgz#fc2d46256ef0bee0d3dbeeca12d39731985019ce"
-  integrity sha512-Ex0aBGZutavI0qdAiMCk7IRHBNKZ8sEGXu1gMdY8W6bIpojknOCfNDw+f9P7auXFKnkwEIcBF8xWQtPgzx3YYA==
+"@inkeep/widgets@^0.2.292":
+  version "0.2.292"
+  resolved "https://registry.yarnpkg.com/@inkeep/widgets/-/widgets-0.2.292.tgz#87ca39a0775c8b60369c98b96dd43c3638460484"
+  integrity sha512-0rykumvl5ufNjhBpWvd+plXV+5x/wNZw6G/VUFRTY/dk2Ot2E7RzMMsYlDCjeGoaEkQBlISJ4NDhbQpyr/RjPg==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@ark-ui/react" "^0.15.0"
-    "@inkeep/color-mode" "^0.0.24"
-    "@inkeep/components" "^0.0.24"
-    "@inkeep/preset" "^0.0.24"
-    "@inkeep/preset-chakra" "^0.0.24"
-    "@inkeep/shared" "^0.0.25"
-    "@inkeep/styled-system" "^0.0.46"
+    "@inkeep/color-mode" "^0.0.26"
+    "@inkeep/components" "^0.0.26"
+    "@inkeep/preset" "^0.0.26"
+    "@inkeep/preset-chakra" "^0.0.26"
+    "@inkeep/shared" "^0.0.27"
+    "@inkeep/styled-system" "^0.0.48"
     "@types/lodash.isequal" "^4.5.7"
     graphql "^16.8.1"
     graphql-ws "^5.14.0"


### PR DESCRIPTION
Bump @inkeep to patch security vulnerability

This PR updates our dependency configuration to explicitly use a patched version of zagjs, addressing the known security vulnerability identified by npm audit and Dependabot alerts.

