### PR TITLE
Fix the docs formatting linter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,12 +7,16 @@ jobs:
     name: Run tests
     runs-on: ubuntu-22.04-2core-arm64
     steps:
-    - uses: actions/checkout@v4
-    - name: Install deps
-      run: yarn && yarn playwright install --with-deps
-    - name: Run unit tests
-      run: yarn test
-    - name: Build Storybook
-      run: yarn storybook:build
-    - name: Run Storybook tests
-      run: yarn storybook:test-ci
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: yarn && yarn playwright install --with-deps
+      - name: Run unit tests
+        run: yarn test
+      - name: Build Storybook
+        run: yarn storybook:build
+      - name: Run Storybook tests
+        run: yarn storybook:test-ci
+        # Changes to server code can break the formatting linter by mistake, so run it to
+        # make sure this hasn't happened.
+      - name: Run the docs formatting linter
+        run: yarn markdown-lint

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -65,7 +65,7 @@ const configLint = {
       {
         lint: true,
         variables: (vfile) => {
-          return loadConfig(getVersion(vfile.path)).variables || {};
+          return loadConfig(getVersion(vfile.path), ".").variables || {};
         },
       },
     ],


### PR DESCRIPTION
The changes in #152 adjusted the signature of `loadConfig`, but did not update the `loadConfig` call in the formatting linter configuration file, `.remarkrc.mjs`.

This change updates the `loadConfig` call and adds `yarn markdown-lint` to the `Run tests` CI job to prevent similar situations in the future.