### PR TITLE
Auto-collapse sidebar categories

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -53,6 +53,11 @@ const config: Config = {
     "./src/styles/global.css",
   ],
   themeConfig: {
+    docs: {
+      sidebar: {
+        autoCollapseCategories: true,
+      },
+    },
     image: "/og-image.png",
     colorMode: {
       defaultMode: "light",


### PR DESCRIPTION
The docs sidebar is particularly complex, so this change enables auto-collapsing non-selecting categories to make it less likely that the sidebar will exceed the browser client height.