### PR TITLE
fix: move `remark-parse` to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-use": "^17.5.0",
     "rehype-highlight": "^7.0.2",
     "remark-mdx": "^2.1.1",
+    "remark-parse": "^10.0.1",
     "vite-node": "^3.0.5"
   },
   "devDependencies": {
@@ -106,7 +107,6 @@
     "remark-copy-linked-files": "^1.5.0",
     "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1",
-    "remark-parse": "^10.0.1",
     "remark-preset-lint-markdown-style-guide": "^5.1.2",
     "remark-rehype": "^10.1.0",
     "remark-validate-links": "^11.0.2",


### PR DESCRIPTION
### Summary

Production deployment is failing with error: `Error: Cannot find module 'remark-parse'`.

Not sure why it was failing earlier (maybe because of `node_modules` cache), but in production builds are running with `NODE_ENV=production`, meaning that packages that are marked as `devDependencies` are not installed in there.

Moving `remark-parse` from `devDependencies` to `dependencies` fixes the issue.
