### PR TITLE
Dependabot and GHA setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Basic `dependabot.yml` file with
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "gha"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - emargetis
+      - taraspos
+      - ptgott
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "nodejs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-web-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - emargetis
+      - ptgott
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    labels:
+      - "dependencies"
+      - "docker" 
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - emargetis
+      - taraspos

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,17 +33,3 @@ updates:
     reviewers:
       - emargetis
       - ptgott
-
-  # Enable version updates for Docker
-  - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
-    directory: "/"
-    # Check for updates once a week
-    labels:
-      - "dependencies"
-      - "docker" 
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - emargetis
-      - taraspos

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
       npm-web-dependencies:
         update-types:
           - "minor"

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -13,7 +13,7 @@ jobs:
     environment: docs-amplify
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
       with:
         aws-region: us-west-2
         role-to-assume: ${{ vars.IAM_ROLE }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,14 +26,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,11 @@ jobs:
     name: Run tests
     runs-on: ubuntu-22.04-2core-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 23
+          cache: 'yarn'
       - name: Install deps
         run: yarn && yarn playwright install --with-deps
       - name: Run unit tests


### PR DESCRIPTION
### Summary

1. Configure Dependabot to bump dependencies automatically
2. Pin all GHA versions
3. Add yarn cache for test job