### PR TITLE
Add a workflow to check the docs site build

### DIFF
--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,0 +1,33 @@
+# Check the docs build with the latest content in each gravitational/teleport
+# submodule before merging docs-website changes.
+name: Check the docs build
+on:
+  merge_group:
+  pull_request:
+    paths:
+      - '.github/workflows/check-build.yaml'
+
+jobs:
+  check-build:
+    name: Check the docs build
+    runs-on: ubuntu-22.04-2core-arm64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 23
+          cache: 'yarn'
+      - name: Install deps
+        run: yarn
+      - name: Prepare docs site configuration
+        # Replace data fetched from Sanity CMS with hardcoded JSON objects to
+        # remove the need to authenticate with Sanity. Each includes the minimal
+        # set of data required for docs builds to succeed.
+        run: |
+          NEW_PACKAGE_JSON=$(jq '.scripts."prepare-sanity-data" = "echo Using pre-populated Sanity data"' package.json);
+          echo "$NEW_PACKAGE_JSON" > package.json;
+          echo "{}" > data/events.json
+          echo '{"bannerButtons":{"second":{"title":"LOG IN","url":"https://teleport.sh"},"first":{"title":"Support","url":"https://goteleport.com/support/"}},"navbarData":{"rightSide":{},"logo":"/favicon.svg","menu":[]}}' > data/navbar.json
+
+      - name: Build the docs with the latest content
+        run: yarn build


### PR DESCRIPTION
Add a `merge_group` check to make sure that docs site builds succeed with the latest `gravitational/docs-website` commit as well as the latest commits on each `gravitational/teleport` submodule.

This prevents situations in which the Amplify preview job succeeds despite the build failing because either:

- `gravitational/teleport` changes cause the build to fail with the latest `gravitational/docs-website` code, despite this succeeding at another version of the content submodules.
- The Amplify preview job misrepresents the success of the Amplify build, which can happen when there is unanticipated output from the Amplify API.