### PR TITLE
Fix the markdown-lint test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,4 +23,4 @@ jobs:
         # Changes to server code can break the formatting linter by mistake, so run it to
         # make sure this hasn't happened.
       - name: Run the docs formatting linter
-        run: yarn markdown-lint
+        run: scripts/lint-test.sh

--- a/scripts/lint-test.sh
+++ b/scripts/lint-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This script checks that the remark linter runs without issue. The linter
+# executes the configuration file .remarkrc.mjs if there is at least one file to
+# lint, so to save linting time, we write a mock file to the content directory.
+
+if [ $(find content -mindepth 2 | wc -l) -gt 0 ]; then
+    echo "Files already exist in the content directory. Running the remark linter without adding a mock file."
+    yarn markdown-lint;
+    exit "$?";
+fi
+
+firstdir=$(find content -type d -maxdepth 1 -mindepth 1 | head -n 1)
+
+mkdir -p "${firstdir}/docs/pages";
+
+cat<<EOF>"${firstdir}/docs/pages/index.mdx"
+---
+title: "Docs Home"
+description: Provides an overview of the docs
+---
+
+First paragraph
+EOF
+
+cat<<EOF>"${firstdir}/docs/config.json"
+{
+  "variables": {},
+  "redirects": []
+}
+EOF
+
+echo "Wrote mock files to ${firstdir}/docs/pages/index.mdx and ${firstdir}/docs/config.json";
+
+yarn markdown-lint
+ret="$?";
+
+rm -rf "${firstdir}/docs";
+
+echo "Cleaned up ${firstdir}/docs";
+exit ${ret};


### PR DESCRIPTION
In the `Run tests` GitHub Actions job, we run the `yarn markdown-lint` script to ensure that changes to custom remark plugins haven't caused the remark config, `.remarkrc.mjs`, to break. Since we run the remark linter in the `gravitational/teleport` CI, this is important to prevent that pipeline from breaking.

In the current `Run tests` config, we run `yarn markdown-lint` without loading submodule content. This is problematic since `remark` only executes the JavaScript in `remarkrc.mjs` if there is at least one file to lint. This means that PRs that introduced runtime errors into the remark config, such as #158, manage to pass the linter, since there were no files to lint in the `Run tests` job.

This change adds a script that writes mock files to a docs content directory before running `yarn markdown-lint`. This way, we can test the `.remarkrc.mjs` config without performing a full submodule load, and the test won't depend on whether a content change happens to introduce a linter error.