### PR TITLE
Fix bug in `remark-version-alias`

### DIFF
--- a/server/remark-version-alias.test.ts
+++ b/server/remark-version-alias.test.ts
@@ -39,7 +39,32 @@ title: My page
 description: My page
 ---
 
-import CodeExample from '@site/content/15.x/examples/access-plugin-minimal/config.go'
+import CodeExample from '@site/content/15.x/examples/access-plugin-minimal/config.go';
+
+This is a paragraph.
+`,
+      path: "docs/mypage.mdx",
+    },
+{
+      description: "three import statements in latest-version docs path",
+      input: `---
+title: My page
+description: My page
+---
+
+import CodeExample from "@version/examples/access-plugin-minimal/config.go";
+import MyImage from "@version/myimg.png";
+import Triangle from "@version/triangle.png";
+
+This is a paragraph.`,
+      expected: `---
+title: My page
+description: My page
+---
+
+import CodeExample from '@site/content/15.x/examples/access-plugin-minimal/config.go';
+import MyImage from '@site/content/15.x/myimg.png';
+import Triangle from '@site/content/15.x/triangle.png';
 
 This is a paragraph.
 `,
@@ -60,7 +85,7 @@ title: My page
 description: My page
 ---
 
-import CodeExample from '@site/content/16.x/examples/access-plugin-minimal/config.go'
+import CodeExample from '@site/content/16.x/examples/access-plugin-minimal/config.go';
 
 This is a paragraph.
 `,
@@ -81,7 +106,7 @@ title: My page
 description: My page
 ---
 
-import CodeExample from '!!raw-loader!@site/content/16.x/examples/access-plugin-minimal/config.go'
+import CodeExample from '!!raw-loader!@site/content/16.x/examples/access-plugin-minimal/config.go';
 
 This is a paragraph.
 `,


### PR DESCRIPTION
Fixes #209

The plugin fails to process multiple successive `import` statements as expected in MDX files because it only operates on `MdxjsEsm` nodes with a single element in the `data.estree.body` array. Multiple successive `import` statements add elements to `body`.

This change replaces the `@version` alias in multiple successive imports by replacing each node, then adding the concatenated replaced values of all imports to the `MdxjsEsm` node's `value`.