### PR TITLE
Respect `sidebar_position` in sidebar ordering

### DIFF
--- a/server/sidebar-order.test.ts
+++ b/server/sidebar-order.test.ts
@@ -25,482 +25,1013 @@ function getDocPageForId(id: string): docPage {
 }
 
 describe("orderSidebarItems", () => {
-  interface testCase {
-    description: string;
-    input: Array<NormalizedSidebarItem>;
-    expected: Array<NormalizedSidebarItem>;
-  }
+  describe("automatic ordering", () => {
+    interface testCase {
+      description: string;
+      input: Array<NormalizedSidebarItem>;
+      expected: Array<NormalizedSidebarItem>;
+    }
 
-  // To write a test case, you can print the items array returned by
-  // defaultSidebarItemsGenerator in docusaurus.config.ts and find the
-  // subarray of items you would like to include.
-  const testCases: Array<testCase> = [
-    {
-      description: "Orders docs pages alphabetically by title",
-      input: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/page-c",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-a",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-b",
-            },
-          ],
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/page-a",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-b",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-c",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      description: "Places introduction pages first",
-      input: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/page-b",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-a",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-introduction",
-            },
-          ],
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/page-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-a",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/page-b",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      description: "Places getting started after introduction",
-      input: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a",
-            },
-          ],
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      description: "alphabetizes introduction  and getting started pages",
-      input: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/b-getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a-getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/c-introduction",
-            },
-          ],
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/a-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/c-introduction",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a-getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-getting-started",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      description: "get started and getting started",
-      input: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/b-get-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/a-getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-getting-started",
-            },
-          ],
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "My Docs Category",
-          items: [
-            {
-              type: "doc",
-              id: "reference/my-category/a-getting-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-get-started",
-            },
-            {
-              type: "doc",
-              id: "reference/my-category/b-getting-started",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      description: "a mix of categories and pages",
-      input: [
-        {
-          type: "category",
-          label: "Applications",
-          items: [
-            {
-              type: "category",
-              label: "Securing Access to Cloud APIs",
-              items: [
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/cloud-apis/aws-console",
-                },
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
-                },
-              ],
-              link: {
+    // To write a test case, you can print the items array returned by
+    // defaultSidebarItemsGenerator in docusaurus.config.ts and find the
+    // subarray of items you would like to include.
+    const testCases: Array<testCase> = [
+      {
+        description: "Orders docs pages alphabetically by title",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
                 type: "doc",
-                id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+                id: "reference/my-category/page-c",
               },
-            },
-            {
-              type: "doc",
-              id: "enroll-resources/application-access/application-access-controls",
-            },
-            {
-              type: "doc",
-              id: "enroll-resources/application-access/getting-started",
-            },
-            {
-              type: "category",
-              label: "Application Access Guides",
-              items: [
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/guides/amazon-athena",
-                },
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/guides/api-access",
-                },
-              ],
-              link: {
+              {
                 type: "doc",
-                id: "enroll-resources/application-access/guides/guides",
+                id: "reference/my-category/page-a",
               },
-            },
-          ],
-          link: {
-            type: "doc",
-            id: "enroll-resources/application-access/application-access",
+              {
+                type: "doc",
+                id: "reference/my-category/page-b",
+              },
+            ],
           },
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "Applications",
-          items: [
-            {
-              type: "doc",
-              id: "enroll-resources/application-access/getting-started",
-            },
-            {
-              type: "doc",
-              id: "enroll-resources/application-access/application-access-controls",
-            },
-            {
-              type: "category",
-              label: "Application Access Guides",
-              items: [
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/guides/amazon-athena",
-                },
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/guides/api-access",
-                },
-              ],
-              link: {
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
                 type: "doc",
-                id: "enroll-resources/application-access/guides/guides",
+                id: "reference/my-category/page-a",
               },
-            },
-            {
-              type: "category",
-              label: "Securing Access to Cloud APIs",
-              items: [
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/cloud-apis/aws-console",
-                },
-                {
-                  type: "doc",
-                  id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
-                },
-              ],
-              link: {
+              {
                 type: "doc",
-                id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+                id: "reference/my-category/page-b",
               },
-            },
-          ],
-          link: {
-            type: "doc",
-            id: "enroll-resources/application-access/application-access",
+              {
+                type: "doc",
+                id: "reference/my-category/page-c",
+              },
+            ],
           },
-        },
-      ],
-    },
-    {
-      description: "nested category",
-      input: [
-        {
-          type: "category",
-          label: "Category A",
-          items: [
-            {
-              type: "category",
-              label: "Category B",
-              items: [
-                {
-                  type: "doc",
-                  id: "category-a/category-b/page-b",
-                },
-                {
-                  type: "doc",
-                  id: "category-a/category-b/page-a",
-                },
-              ],
-              link: {
+        ],
+      },
+      {
+        description: "Places introduction pages first",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
                 type: "doc",
-                id: "category-a/category-b/category-b",
+                id: "reference/my-category/page-b",
               },
-            },
-            {
-              type: "category",
-              label: "Category C",
-              items: [
-                {
-                  type: "doc",
-                  id: "category-a/category-b/category-c/page-b",
-                },
-                {
-                  type: "doc",
-                  id: "category-a/category-b/category-c/page-a",
-                },
-              ],
-              link: {
+              {
                 type: "doc",
-                id: "category-a/category-b/category-b/category-c/category-c",
+                id: "reference/my-category/page-a",
               },
-            },
-            {
-              type: "doc",
-              id: "category-a/page-a",
-            },
-          ],
-          link: {
-            type: "doc",
-            id: "category-a/category-a",
+              {
+                type: "doc",
+                id: "reference/my-category/page-introduction",
+              },
+            ],
           },
-        },
-      ],
-      expected: [
-        {
-          type: "category",
-          label: "Category A",
-          items: [
-            {
-              type: "category",
-              label: "Category B",
-              items: [
-                {
-                  type: "doc",
-                  id: "category-a/category-b/page-a",
-                },
-                {
-                  type: "doc",
-                  id: "category-a/category-b/page-b",
-                },
-              ],
-              link: {
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
                 type: "doc",
-                id: "category-a/category-b/category-b",
+                id: "reference/my-category/page-introduction",
               },
-            },
-            {
-              type: "category",
-              label: "Category C",
-              items: [
-                {
-                  type: "doc",
-                  id: "category-a/category-b/category-c/page-a",
-                },
-                {
-                  type: "doc",
-                  id: "category-a/category-b/category-c/page-b",
-                },
-              ],
-              link: {
+              {
                 type: "doc",
-                id: "category-a/category-b/category-b/category-c/category-c",
+                id: "reference/my-category/page-a",
               },
-            },
-            {
-              type: "doc",
-              id: "category-a/page-a",
-            },
-          ],
-          link: {
-            type: "doc",
-            id: "category-a/category-a",
+              {
+                type: "doc",
+                id: "reference/my-category/page-b",
+              },
+            ],
           },
-        },
-      ],
-    },
-  ];
+        ],
+      },
+      {
+        description: "Places getting started after introduction",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a",
+              },
+            ],
+          },
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        description: "alphabetizes introduction  and getting started pages",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/b-getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a-getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a-introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/c-introduction",
+              },
+            ],
+          },
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/a-introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/c-introduction",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a-getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-getting-started",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        description: "get started and getting started",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/b-get-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/a-getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-getting-started",
+              },
+            ],
+          },
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "reference/my-category/a-getting-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-get-started",
+              },
+              {
+                type: "doc",
+                id: "reference/my-category/b-getting-started",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        description: "a mix of categories and pages",
+        input: [
+          {
+            type: "category",
+            label: "Applications",
+            items: [
+              {
+                type: "category",
+                label: "Securing Access to Cloud APIs",
+                items: [
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/cloud-apis/aws-console",
+                  },
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+                },
+              },
+              {
+                type: "doc",
+                id: "enroll-resources/application-access/application-access-controls",
+              },
+              {
+                type: "doc",
+                id: "enroll-resources/application-access/getting-started",
+              },
+              {
+                type: "category",
+                label: "Application Access Guides",
+                items: [
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/guides/amazon-athena",
+                  },
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/guides/api-access",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/guides",
+                },
+              },
+            ],
+            link: {
+              type: "doc",
+              id: "enroll-resources/application-access/application-access",
+            },
+          },
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "Applications",
+            items: [
+              {
+                type: "doc",
+                id: "enroll-resources/application-access/getting-started",
+              },
+              {
+                type: "doc",
+                id: "enroll-resources/application-access/application-access-controls",
+              },
+              {
+                type: "category",
+                label: "Application Access Guides",
+                items: [
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/guides/amazon-athena",
+                  },
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/guides/api-access",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "enroll-resources/application-access/guides/guides",
+                },
+              },
+              {
+                type: "category",
+                label: "Securing Access to Cloud APIs",
+                items: [
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/cloud-apis/aws-console",
+                  },
+                  {
+                    type: "doc",
+                    id: "enroll-resources/application-access/cloud-apis/azure-aks-workload-id",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "enroll-resources/application-access/cloud-apis/cloud-apis",
+                },
+              },
+            ],
+            link: {
+              type: "doc",
+              id: "enroll-resources/application-access/application-access",
+            },
+          },
+        ],
+      },
+      {
+        description: "nested category",
+        input: [
+          {
+            type: "category",
+            label: "Category A",
+            items: [
+              {
+                type: "category",
+                label: "Category B",
+                items: [
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/page-b",
+                  },
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/page-a",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "category-a/category-b/category-b",
+                },
+              },
+              {
+                type: "category",
+                label: "Category C",
+                items: [
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/category-c/page-b",
+                  },
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/category-c/page-a",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "category-a/category-b/category-b/category-c/category-c",
+                },
+              },
+              {
+                type: "doc",
+                id: "category-a/page-a",
+              },
+            ],
+            link: {
+              type: "doc",
+              id: "category-a/category-a",
+            },
+          },
+        ],
+        expected: [
+          {
+            type: "category",
+            label: "Category A",
+            items: [
+              {
+                type: "category",
+                label: "Category B",
+                items: [
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/page-a",
+                  },
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/page-b",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "category-a/category-b/category-b",
+                },
+              },
+              {
+                type: "category",
+                label: "Category C",
+                items: [
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/category-c/page-a",
+                  },
+                  {
+                    type: "doc",
+                    id: "category-a/category-b/category-c/page-b",
+                  },
+                ],
+                link: {
+                  type: "doc",
+                  id: "category-a/category-b/category-b/category-c/category-c",
+                },
+              },
+              {
+                type: "doc",
+                id: "category-a/page-a",
+              },
+            ],
+            link: {
+              type: "doc",
+              id: "category-a/category-a",
+            },
+          },
+        ],
+      },
+    ];
 
-  test.each(testCases)("$description", (c) => {
-    const actual = orderSidebarItems(c.input, getDocPageForId);
-    expect(actual).toEqual(c.expected);
+    test.each(testCases)("$description", (c) => {
+      const actual = orderSidebarItems(c.input, getDocPageForId);
+      expect(actual).toEqual(c.expected);
+    });
+  });
+
+  describe("sidebar position", () => {
+    const idToDocPage = {
+      "page-a": {
+        title: "Page A",
+        id: "page-a",
+        frontmatter: {
+          title: "Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/page-a.mdx",
+        sourceDirName: "",
+      },
+      "page-b": {
+        title: "Page B",
+        id: "page-b",
+        frontmatter: {
+          title: "Page B",
+          description: "Page B",
+        },
+        source: "@site/docs/page-b.mdx",
+        sourceDirName: "",
+      },
+      "page-c": {
+        title: "Page C",
+        id: "page-c",
+        frontmatter: {
+          title: "Page C",
+          description: "Page C",
+        },
+        source: "@site/docs/page-c.mdx",
+        sourceDirName: "",
+      },
+      "page-d": {
+        title: "Introduction",
+        id: "page-d",
+        frontmatter: {
+          title: "Introduction",
+          description: "Introduction",
+        },
+        source: "@site/docs/page-d.mdx",
+        sourceDirName: "",
+      },
+      "page-e": {
+        title: "Page E",
+        id: "page-e",
+        frontmatter: {
+          title: "Page E",
+          description: "Page E",
+          sidebar_position: 2,
+        },
+        sidebarPosition: 2,
+        source: "@site/docs/page-e.mdx",
+        sourceDirName: "",
+      },
+      "page-f": {
+        title: "Getting Started",
+        id: "page-f",
+        frontmatter: {
+          title: "Getting Started",
+          description: "Getting Started",
+        },
+        source: "@site/docs/page-f.mdx",
+        sourceDirName: "",
+      },
+      "page-g": {
+        title: "Introduction",
+        id: "page-g",
+        frontmatter: {
+          title: "Introduction",
+          description: "Introduction",
+        },
+        source: "@site/docs/page-g.mdx",
+        sourceDirName: "",
+        sidebarPosition: 3,
+      },
+    };
+
+    interface testCase {
+      description: string;
+      input: Array<NormalizedSidebarItem>;
+      expected: Array<NormalizedSidebarItem>;
+    }
+
+    const testCases: Array<testCase> = [
+      {
+        description: "pages ordered with fixed sidebar position",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-c",
+              },
+              {
+                type: "doc",
+                id: "page-a",
+              },
+              {
+                type: "doc",
+                id: "page-b",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+            ],
+          },
+        ],
+        // Page E has a sidebar position of 2, so it must occupy that position.
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-a",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+              {
+                type: "doc",
+                id: "page-b",
+              },
+              {
+                type: "doc",
+                id: "page-c",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        description: "getting started and introduction",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-f",
+              },
+              {
+                type: "doc",
+                id: "page-a",
+              },
+              {
+                type: "doc",
+                id: "page-d",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+            ],
+          },
+        ],
+        // Page E has a sidebar position of 2, so it must occupy that position.
+        // We order the other pages around that one, starting with Introduction,
+        // then Getting Started, then Page A.
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-d",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+              {
+                type: "doc",
+                id: "page-f",
+              },
+              {
+                type: "doc",
+                id: "page-a",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        description: "intro page with sidebar position",
+        input: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-g",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+              {
+                type: "doc",
+                id: "page-a",
+              },
+              {
+                type: "doc",
+                id: "page-b",
+              },
+            ],
+          },
+        ],
+        // Page E has a sidebar position of 2, so it must occupy that position.
+        // The Introduction page (page-g) has a sidebar position of 3, which
+        // supersedes the Introduction title. We order Page A and Page B separately,
+        // around the fixed-position pages.
+        expected: [
+          {
+            type: "category",
+            label: "My Docs Category",
+            items: [
+              {
+                type: "doc",
+                id: "page-a",
+              },
+              {
+                type: "doc",
+                id: "page-e",
+              },
+              {
+                type: "doc",
+                id: "page-g",
+              },
+              {
+                type: "doc",
+                id: "page-b",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    test.each(testCases)("$description", (c) => {
+      const actual = orderSidebarItems(c.input, (id: string): docPage => {
+        return idToDocPage[id];
+      });
+      expect(actual).toEqual(c.expected);
+    });
+  });
+
+  describe("ordering category index pages", () => {
+    const idToDocPage = {
+      "section-a/section-a": {
+        title: "Section A",
+        id: "section-a/section-a",
+        frontmatter: {
+          title: "Section A",
+          description: "Section A",
+        },
+        source: "@site/docs/section-a/section-a.mdx",
+        sourceDirName: "section-a",
+      },
+      "section-a/page-a": {
+        title: "Section A Page A",
+        id: "section-a/page-a",
+        frontmatter: {
+          title: "Section A Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/section-a/page-a.mdx",
+        sourceDirName: "",
+      },
+      "section-a/page-b": {
+        title: "Section A Page B",
+        id: "section-a/page-b",
+        frontmatter: {
+          title: "Section A Page B",
+          description: "Page B",
+        },
+        source: "@site/docs/section-a/page-b.mdx",
+        sourceDirName: "",
+      },
+      "section-b/section-b": {
+        title: "Section B",
+        id: "section-b/section-b",
+        frontmatter: {
+          title: "Section B",
+          description: "Section B",
+        },
+        source: "@site/docs/section-b/section-b.mdx",
+        sourceDirName: "section-b",
+        sidebarPosition: 2,
+      },
+      "section-b/page-a": {
+        title: "Section B Page A",
+        id: "section-b/page-a",
+        frontmatter: {
+          title: "Section B Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/section-b/page-a.mdx",
+        sourceDirName: "section-b",
+        sidebarPosition: 2,
+      },
+      "section-b/page-b": {
+        title: "Section B Page B",
+        id: "section-b/page-b",
+        frontmatter: {
+          title: "Section B Page B",
+          description: "Page B",
+        },
+        source: "@site/docs/section-b/page-b.mdx",
+        sourceDirName: "section-b",
+      },
+      intro: {
+        title: "Introduction",
+        id: "intro",
+        frontmatter: {
+          title: "Introduction",
+          description: "Introduction",
+        },
+        source: "@site/docs/intro.mdx",
+        sourceDirName: "",
+      },
+    };
+
+    const input: Array<NormalizedSidebarItem> = [
+      {
+        type: "category",
+        label: "Section A",
+        link: {
+          type: "doc",
+          id: "section-a/section-a",
+        },
+        items: [
+          {
+            type: "doc",
+            id: "section-a/page-a",
+          },
+          {
+            type: "doc",
+            id: "section-a/page-b",
+          },
+        ],
+      },
+      {
+        type: "category",
+        label: "Section B",
+        link: {
+          type: "doc",
+          id: "section-b/section-b",
+        },
+        items: [
+          {
+            type: "doc",
+            id: "section-b/page-a",
+          },
+          {
+            type: "doc",
+            id: "section-b/page-b",
+          },
+        ],
+      },
+      {
+        type: "doc",
+        id: "intro",
+      },
+    ];
+
+    // The index page in Section B has a sidebar position of 2, so we sort
+    // Introduction and Section A around it.
+    const expected: Array<NormalizedSidebarItem> = [
+      {
+        type: "doc",
+        id: "intro",
+      },
+      {
+        type: "category",
+        label: "Section B",
+        link: {
+          type: "doc",
+          id: "section-b/section-b",
+        },
+        items: [
+          // Page B has a sidebar position
+          {
+            type: "doc",
+            id: "section-b/page-b",
+          },
+          {
+            type: "doc",
+            id: "section-b/page-a",
+          },
+        ],
+      },
+      {
+        type: "category",
+        label: "Section A",
+        link: {
+          type: "doc",
+          id: "section-a/section-a",
+        },
+        items: [
+          {
+            type: "doc",
+            id: "section-a/page-a",
+          },
+          {
+            type: "doc",
+            id: "section-a/page-b",
+          },
+        ],
+      },
+    ];
+
+    const actual = orderSidebarItems(input, (id: string): docPage => {
+      return idToDocPage[id];
+    });
+    expect(actual).toEqual(expected);
+  });
+
+  test("identical sidebar positions", () => {
+    const idToDocPage = {
+      "page-a": {
+        title: "Page A",
+        id: "page-a",
+        frontmatter: {
+          title: "Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/page-a.mdx",
+        sourceDirName: "",
+        sidebarPosition: 2,
+      },
+      "page-b": {
+        title: "Page B",
+        id: "page-b",
+        frontmatter: {
+          title: "Page B",
+          description: "Page B",
+        },
+        source: "@site/docs/page-b.mdx",
+        sourceDirName: "",
+        sidebarPosition: 2,
+      },
+    };
+
+    const input: Array<NormalizedSidebarItem> = [
+      {
+        type: "category",
+        label: "My docs category",
+        items: [
+          {
+            type: "doc",
+            id: "page-b",
+          },
+          {
+            type: "doc",
+            id: "page-a",
+          },
+        ],
+      },
+    ];
+
+    expect(() => {
+      orderSidebarItems(input, (id: string): docPage => {
+        return idToDocPage[id];
+      });
+    }).toThrow(
+      "page with ID page-a has the same sidebar_position frontmatter value as the page with ID page-b in the same sidebar section",
+    );
+  });
+
+  test("sidebar position out of bounds", () => {
+    const idToDocPage = {
+      "page-a": {
+        title: "Page A",
+        id: "page-a",
+        frontmatter: {
+          title: "Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/page-a.mdx",
+        sourceDirName: "",
+        sidebarPosition: 5,
+      },
+      "page-b": {
+        title: "Page B",
+        id: "page-b",
+        frontmatter: {
+          title: "Page B",
+          description: "Page B",
+        },
+        source: "@site/docs/page-b.mdx",
+        sourceDirName: "",
+      },
+    };
+
+    const input: Array<NormalizedSidebarItem> = [
+      {
+        type: "category",
+        label: "My docs category",
+        items: [
+          {
+            type: "doc",
+            id: "page-b",
+          },
+          {
+            type: "doc",
+            id: "page-a",
+          },
+        ],
+      },
+    ];
+
+    expect(() => {
+      orderSidebarItems(input, (id: string): docPage => {
+        return idToDocPage[id];
+      });
+    }).toThrow(
+      "page with ID page-a has a sidebar position (5) that exceeds the number of items in the sidebar section (2)",
+    );
   });
 });
 

--- a/server/sidebar-order.ts
+++ b/server/sidebar-order.ts
@@ -12,31 +12,43 @@ export interface docPage {
   };
   source: string;
   sourceDirName: string;
-  sideBarPosition?: number;
+  sidebarPosition?: number;
 }
 
-interface titleFeatures {
+interface orderAttributes {
   title: string;
   isIntroduction: boolean;
   isGettingStarted: boolean;
+  sidebarPosition?: number;
+  id?: string;
 }
 
-// getTitleFeatures extracts attributes of a NormalizedSidebarItem's title (or
-// label, in the case of category pages) for sorting. Titles are lowercased.
-const getTitleFeatures = (
+// getOrderAttributes extracts attributes of a NormalizedSidebarItem's title and
+// sidebar position for sorting. Titles are lowercased. In the case of a
+// category index page, we use the sidebar position of the page's link, if this
+// is present. Otherwise, we sort by the category label.
+const getOrderAttributes = (
   item: NormalizedSidebarItem,
-  getter: (id: string) => docPage
-): titleFeatures => {
+  getter: (id: string) => docPage,
+): orderAttributes => {
   let title: string;
+  let sidebarPosition: number;
+  let id: string;
   switch (item.type) {
     case "doc":
-      title = getter((item as SidebarItemDoc).id).title;
+      const page = getter((item as SidebarItemDoc).id);
+      title = page.title;
+      sidebarPosition = page.sidebarPosition;
+      id = page.id;
       break;
     case "category":
-      if (!(item as NormalizedSidebarItemCategory).label) {
-        return undefined;
+      const cat = item as NormalizedSidebarItemCategory;
+      if (cat.link && cat.link.type == "doc") {
+        const page = getter(cat.link.id);
+        sidebarPosition = page.sidebarPosition;
+        id = page.id;
       }
-      title = item.label;
+      title = cat.label;
       break;
     default:
       return undefined;
@@ -46,68 +58,102 @@ const getTitleFeatures = (
     title: title.toLowerCase(),
     isIntroduction: title.toLowerCase().includes("introduction"),
     isGettingStarted: title.toLowerCase().match(/get(ting)? started/) !== null,
+    sidebarPosition: sidebarPosition,
+    id: id,
   };
 };
 
 export const orderSidebarItems = (
   items: Array<NormalizedSidebarItem>,
-  getter: (id: string) => docPage
+  getter: (id: string) => docPage,
 ): Array<NormalizedSidebarItem> => {
-  const newItems = [];
+  const newItems = new Array(items.length);
+  const unsortedItems = [];
 
-  // Start by recursively descending into items and sorting their children.
   items.forEach((item) => {
+    // Start by recursively descending into items and sorting their children.
     let newItem = Object.assign({}, item);
     const cat = newItem as NormalizedSidebarItemCategory;
     if (cat.items) {
       cat.items = orderSidebarItems(cat.items, getter);
-      newItems.push(cat);
+    }
+
+    // If the item has a sidebar position, add it to the final array. We'll sort
+    // the remaining items automatically before adding them to the empty slots
+    // in the final array.
+    const { sidebarPosition, id } = getOrderAttributes(newItem, getter);
+    if (!sidebarPosition) {
+      unsortedItems.push(newItem);
       return;
     }
-    newItems.push(item);
+
+    if (sidebarPosition > items.length) {
+      throw new Error(
+        `page with ID ${id} has a sidebar position (${sidebarPosition}) that exceeds the number of items in the sidebar section (${items.length})`,
+      );
+    }
+
+    const sideBarIndex = sidebarPosition - 1;
+
+    if (newItems[sideBarIndex]) {
+      throw new Error(
+        `page with ID ${id} has the same sidebar_position frontmatter value as the page with ID ${newItems[sideBarIndex].id} in the same sidebar section`,
+      );
+    }
+    newItems[sideBarIndex] = newItem;
   });
 
-  return newItems.sort((a, b) => {
-    const aTitle = getTitleFeatures(a, getter);
-    const bTitle = getTitleFeatures(b, getter);
+  unsortedItems.sort((a, b) => {
+    const attrsA = getOrderAttributes(a, getter);
+    const attrsB = getOrderAttributes(b, getter);
 
     // We can't sort by title, so don't compare.
-    if (aTitle == undefined || bTitle == undefined) {
+    if (attrsA == undefined || attrsB == undefined) {
       return 0;
     }
 
     // Sort pages first if they include "introduction" (case-insensitive) in
     // the title.
-    if (aTitle.isIntroduction && !bTitle.isIntroduction) {
+    if (attrsA.isIntroduction && !attrsB.isIntroduction) {
       return -1;
     }
-    if (bTitle.isIntroduction && !aTitle.isIntroduction) {
+    if (attrsB.isIntroduction && !attrsA.isIntroduction) {
       return 1;
     }
 
     // Sort pages earlier if they are getting started guides.
-    if (aTitle.isGettingStarted && !bTitle.isGettingStarted) {
+    if (attrsA.isGettingStarted && !attrsB.isGettingStarted) {
       return -1;
     }
-    if (bTitle.isGettingStarted && !aTitle.isGettingStarted) {
+    if (attrsB.isGettingStarted && !attrsA.isGettingStarted) {
       return 1;
     }
 
     // If there's nothing special about one title relative to the other,
     // sort them alphabetically.
-    if (aTitle.title >= bTitle.title) {
+    if (attrsA.title >= attrsB.title) {
       return 1;
     } else {
       return -1;
     }
   });
+
+  // Add the sorted items to slots in the array not already occupied by items
+  // with a sidebar_position.
+  for (let i = 0; i < newItems.length; i++) {
+    if (!newItems[i]) {
+      newItems[i] = unsortedItems.shift();
+    }
+  }
+
+  return newItems;
 };
 
 // removeRedundantItems removes top-level category index pages from the sidebar,
 // since we expect these to be defined as links within each top-level category.
 export const removeRedundantItems = (
   items: Array<NormalizedSidebarItem>,
-  dirname: string
+  dirname: string,
 ): Array<NormalizedSidebarItem> => {
   // Return all items except for the one with the ID of the index page to
   // remove from the body of the sidebar section. We expect the top-level category index


### PR DESCRIPTION
Closes #163

The custom logic we use to order the Docusuarus-generated sidebar does not respect the `sidebar_position` frontmatter field. To fix this, retrieve the `sidebar_position` value from docs page sidebar entries. For a sidebar category, retrieve the category index page and use its `sidebar_position`.

The ordering logic now works like this:
- Insert items with a predefined sidebar position at the required indices within the final sidebar item array.
- Insert the remaining sidebar items into the empty slots in the final array. Order these items in the usual order, sorting alphabetically by title (or category label) and placing items with "Introduction" and "Get(ting)? Started" before alphabetized items.