### PR TITLE
Add a custom 404 component

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "storybook:build": "storybook build",
     "storybook:test-ci": "npx concurrently --kill-others --success first --names \"STORYBOOK,TESTS\" -c \"magenta,blue\" \"npx http-server -a 127.0.0.1 --silent storybook-static --port 6006\" \"npx wait-on tcp:127.0.0.1:6006 && yarn storybook:test --url http://127.0.0.1:6006/storybook-static \"",
     "storybook:test": "test-storybook",
-    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --trace-warnings --experimental-vm-modules\" jest --config ./jest.config.mjs server/*.test.ts src/theme/**/*.test.ts"
+    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --trace-warnings --experimental-vm-modules\" jest --config ./jest.config.mjs server/*.test.ts src/theme/**/*.test.ts src/utils/*.test.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/components/GitHubIssueLink/index.tsx
+++ b/src/components/GitHubIssueLink/index.tsx
@@ -1,36 +1,10 @@
 import styles from "./GitHubIssueLink.module.css";
+import { getReportIssueURL } from "/src/utils/github-issue";
 
 export interface GitHubIssueLinkProps {
   pathname: string;
 }
 
-const getIssueTitle = function (pagePath: string) {
-  return encodeURIComponent(`[docs] ${pagePath}: <DESCRIBE YOUR ISSUE>`);
-};
-
-const getIssueBody = function (pagePath: string) {
-  return encodeURIComponent(`## Applies To
-
-${pagePath}
-
-## Details
-
-<!-- Describe the documentation improvements you wish to see. -->
-
-## How will we know this is resolved?
-
-<!-- Briefly describe a test we can carry out. Scope this as narrowly as possible. -->
-
-## Related Issues
-
-<!-- Please make an effort to find related issues on GitHub and list them here. This makes a big difference in how we prioritize and schedule work. -->
-`);
-};
-
-export const getReportIssueURL = function (pagePath: string): string {
-  const mdxPath = "`" + pagePath + "`";
-  return `https://github.com/gravitational/teleport/issues/new?template=documentation.md&labels=documentation&title=${getIssueTitle(mdxPath)}&body=${getIssueBody(mdxPath)}`;
-};
 export const GitHubIssueLink = function ({ pathname }: GitHubIssueLinkProps) {
   return (
     <p className={styles.githubLink}>

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,89 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import Translate from "@docusaurus/Translate";
+import type { Props } from "@theme/NotFound/Content";
+import Heading from "@theme/Heading";
+import { useLocation } from "@docusaurus/router";
+import { getReportIssueURL } from "/src/utils/github-issue";
+import { useDocById } from "@docusaurus/plugin-content-docs/client";
+import useGlobalData from "@docusaurus/useGlobalData";
+import {
+  possibleMovedPages,
+  nearestAvailableCategoryIndex,
+} from "/src/utils/suggestions";
+import Search from "/src/components/Search";
+
+export default function NotFoundContent({ className }: Props): ReactNode {
+  const { pathname } = useLocation();
+
+  const data = useGlobalData();
+  if (
+    !data.hasOwnProperty("docusaurus-plugin-content-docs") &&
+    !data["docusaurus-plugin-content-docs"].hasOwnProperty("default") &&
+    !data["docusaurus-plugin-content-docs"].default.hasOwnProperty("versions")
+  ) {
+    throw new Error(
+      "plugin-content-docs is not configured - enable it in docusaurus.config.ts",
+    );
+  }
+
+  const { versions } = data["docusaurus-plugin-content-docs"].default;
+
+  const altPages = possibleMovedPages(pathname, versions) || [];
+  const nearestIndex = nearestAvailableCategoryIndex(pathname, versions);
+  if (nearestIndex != undefined) {
+    altPages.push(nearestIndex);
+  }
+
+  const altLinks = altPages.map((p) => {
+    const { title } = useDocById(p.id);
+    return (
+      <li key={p.path}>
+        <a href={p.path}>{title}</a>
+      </li>
+    );
+  });
+
+  return (
+    <main className={clsx("container margin-vert--xl", className)}>
+      <div className="row">
+        <div className="col col--6 col--offset-3">
+          <Heading as="h1" className="hero__title">
+            <Translate
+              id="theme.NotFound.title"
+              description="The title of the 404 page"
+            >
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>
+            The page you are looking for does not exist on the Teleport docs
+            site.
+          </p>
+          {altLinks.length > 0 && (
+            <>
+              <p>
+                {
+                  "You may find what you are looking for in the following locations:"
+                }
+              </p>
+              <ul>{altLinks}</ul>
+            </>
+          )}
+          <p>{"Search the docs:"}</p>
+          <p><Search /></p>
+          <p>
+            {"If the URL path is correct, you can "}
+            <a href={getReportIssueURL(pathname)} target={"_blank"}>
+              {"report an issue on GitHub"}
+            </a>
+            {"."}
+          </p>
+          <p>
+            <a href="/">Go back to the docs home page.</a>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -1,0 +1,20 @@
+import React, {type ReactNode} from 'react';
+import {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+
+export default function Index(): ReactNode {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}

--- a/src/utils/github-issue.ts
+++ b/src/utils/github-issue.ts
@@ -1,0 +1,27 @@
+const getIssueTitle = function (pagePath: string) {
+  return encodeURIComponent(`[docs] ${pagePath}: <DESCRIBE YOUR ISSUE>`);
+};
+
+const getIssueBody = function (pagePath: string) {
+  return encodeURIComponent(`## Applies To
+
+${pagePath}
+
+## Details
+
+<!-- Describe the documentation improvements you wish to see. -->
+
+## How will we know this is resolved?
+
+<!-- Briefly describe a test we can carry out. Scope this as narrowly as possible. -->
+
+## Related Issues
+
+<!-- Please make an effort to find related issues on GitHub and list them here. This makes a big difference in how we prioritize and schedule work. -->
+`);
+};
+
+export const getReportIssueURL = function (pagePath: string): string {
+  const mdxPath = "`" + pagePath + "`";
+  return `https://github.com/gravitational/teleport/issues/new?template=documentation.md&labels=documentation&title=${getIssueTitle(mdxPath)}&body=${getIssueBody(mdxPath)}`;
+};

--- a/src/utils/suggestions.test.ts
+++ b/src/utils/suggestions.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  DocsVersion,
+  DocPathInfo,
+  possibleMovedPages,
+  nearestAvailableCategoryIndex,
+} from "./suggestions";
+
+describe("possibleMovedPages", () => {
+  interface testCase {
+    description: string;
+    slug: string;
+    versions: Array<DocsVersion>;
+    expected: Array<DocPathInfo>;
+  }
+
+  const testCases: Array<testCase> = [
+    {
+      description: "regular docs pages, one version",
+      slug: "/ver/18.x/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/get-started",
+              path: "/ver/18.x/enroll-resources/application-access/get-started/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/database-access/get-started",
+              path: "/ver/18.x/enroll-resources/database-access/get-started/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/database-access/postgres",
+              path: "/ver/18.x/enroll-resources/database-access/postgres/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          id: "enroll-resources/application-access/get-started",
+          path: "/ver/18.x/enroll-resources/application-access/get-started/",
+          sidebar: "docs",
+        },
+        {
+          id: "enroll-resources/database-access/get-started",
+          path: "/ver/18.x/enroll-resources/database-access/get-started/",
+          sidebar: "docs",
+        },
+      ],
+    },
+    {
+      description: "regular docs pages, multiple versions",
+      slug: "/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/get-started",
+              path: "/ver/18.x/enroll-resources/application-access/get-started/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/application-access/grafana",
+              path: "/ver/18.x/enroll-resources/application-access/grafana",
+              sidebar: "docs",
+            },
+          ],
+        },
+        {
+          name: "latest",
+          label: "17.x",
+          isLast: true,
+          path: "/",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/get-started",
+              path: "/enroll-resources/application-access/get-started/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/application-access/grafana",
+              path: "/enroll-resources/application-access/grafana",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          id: "enroll-resources/application-access/get-started",
+          path: "/enroll-resources/application-access/get-started/",
+          sidebar: "docs",
+        },
+      ],
+    },
+    {
+      description: "category index page",
+      slug: "/ver/18.x/application-access/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/application-access",
+              path: "/ver/18.x/enroll-resources/application-access/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/application-access/get-started",
+              path: "/ver/18.x/enroll-resources/aplication-access/get-started/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: [
+        {
+          id: "enroll-resources/application-access/application-access",
+          path: "/ver/18.x/enroll-resources/application-access/",
+          sidebar: "docs",
+        },
+      ],
+    },
+  ];
+
+  test.each(testCases)("$description", (c) => {
+    expect(possibleMovedPages(c.slug, c.versions)).toEqual(c.expected);
+  });
+});
+
+describe("nearestAvailableCategoryIndex", () => {
+  interface testCase {
+    description: string;
+    slug: string;
+    versions: Array<DocsVersion>;
+    expected: DocPathInfo;
+  }
+
+  const testCases: Array<testCase> = [
+    {
+      description: "one version, base section",
+      slug: "/ver/18.x/enroll-resources/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/application-access",
+              path: "/ver/18.x/enroll-resources/application-access/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/application-access/grafana",
+              path: "/ver/18.x/enroll-resources/aplication-access/grafana/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: {
+        id: "enroll-resources/application-access/application-access",
+        path: "/ver/18.x/enroll-resources/application-access/",
+        sidebar: "docs",
+      },
+    },
+    {
+      description: "multiple versions, base section",
+      slug: "/ver/18.x/enroll-resources/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/application-access",
+              path: "/ver/18.x/enroll-resources/application-access/",
+              sidebar: "docs",
+            },
+          ],
+        },
+        {
+          name: "19.x",
+          label: "19.x",
+          isLast: false,
+          path: "/ver/19.x.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/application-access/application-access",
+              path: "/ver/19.x/enroll-resources/application-access/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: {
+        id: "enroll-resources/application-access/application-access",
+        path: "/ver/18.x/enroll-resources/application-access/",
+        sidebar: "docs",
+      },
+    },
+    {
+      description: "one version, base-1 section",
+      slug: "/ver/18.x/enroll-resources/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "enroll-resources/enroll-resources",
+              path: "/ver/18.x/enroll-resources/",
+              sidebar: "docs",
+            },
+            {
+              id: "enroll-resources/get-started",
+              path: "/ver/18.x/enroll-resources/get-started/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: {
+        id: "enroll-resources/enroll-resources",
+        path: "/ver/18.x/enroll-resources/",
+        sidebar: "docs",
+      },
+    },
+    {
+      description: "no match",
+      slug: "/ver/18.x/enroll-resources/application-access/get-started/",
+      versions: [
+        {
+          name: "current",
+          label: "18.x (unreleased)",
+          isLast: false,
+          path: "/ver/18.x",
+          mainDocId: "index",
+          docs: [
+            {
+              id: "get-started/get-started",
+              path: "/ver/18.x/get-started/",
+              sidebar: "docs",
+            },
+          ],
+        },
+      ],
+      expected: undefined,
+    },
+  ];
+
+  test.each(testCases)("$description", (c) => {
+    expect(nearestAvailableCategoryIndex(c.slug, c.versions)).toEqual(
+      c.expected,
+    );
+  });
+});

--- a/src/utils/suggestions.ts
+++ b/src/utils/suggestions.ts
@@ -1,0 +1,103 @@
+export interface DocsVersion {
+  name: string;
+  label: string;
+  isLast: boolean;
+  path: string;
+  mainDocId: string;
+  docs: Array<DocPathInfo>;
+}
+
+export interface DocPathInfo {
+  id: string;
+  path: string;
+  sidebar: string;
+}
+
+// possibleMovedPages returns an array of path information for pages with the
+// same final path segment as slug.
+export const possibleMovedPages = function (
+  urlpath: string,
+  nav: Array<DocsVersion>,
+): Array<DocPathInfo> {
+  // Assemble a map of final path segments to path info so we can perform a
+  // lookup.
+  const slugsToPathInfo = new Map();
+  nav.forEach((v) => {
+    if (!urlpath.startsWith(v.path)) {
+      return;
+    }
+    v.docs.forEach((d) => {
+      // Obtain the slug from the page ID. This is guaranteed to match the
+      // expression since it comes from Docusaurus.
+      const name = d.id.match(/[^\/]+$/)[0];
+      if (!slugsToPathInfo.has(name)) {
+        slugsToPathInfo.set(name, [d]);
+        return;
+      }
+      const pathinfo = slugsToPathInfo.get(name);
+      pathinfo.push(d);
+      slugsToPathInfo.set(name, pathinfo);
+    });
+  });
+
+  const slug = urlpath.match(/([^\/]+)\/?$/);
+  if (!slug || !slug[1]) {
+    return [];
+  }
+
+  return slugsToPathInfo.get(slug[1]);
+};
+
+// getPathDir takes a URL path with leading and trailing slashes and returns all
+// but final path segment. getPathDir does not test for a well-formatted input
+// since this comes from Docusaurus.
+function getPathDir(path: string): string {
+  if (path === "/") {
+    return "/";
+  }
+
+  // Remove the leading and trailing slashes, then split into an array of path
+  // segments.
+  const segs = path.slice(1, -1).split("/");
+
+  // Return the preceding path, which is either the root or the path leading
+  // up to the final segment.
+  if (segs.length == 1) {
+    return "/";
+  }
+  segs.pop();
+  return "/" + segs.join("/") + "/";
+}
+
+export const nearestAvailableCategoryIndex = function (
+  urlpath: string,
+  nav: Array<DocsVersion>,
+): DocPathInfo {
+  const sectionIndexMap = new Map();
+  nav.forEach((v) => {
+    if (!urlpath.startsWith(v.path)) {
+      return;
+    }
+
+    // Add each section index page path to the map
+    v.docs.forEach((d) => {
+      const slug = d.path.match(/([^\/]+)\/?$/);
+      if (!slug || !slug[1]) {
+        return;
+      }
+
+      if (d.id.endsWith(slug[1] + "/" + slug[1])) {
+        sectionIndexMap.set(d.path, d);
+      }
+    });
+  });
+
+  // Traverse the missing URL path backwards, one segment at a time, until we
+  // find one in the map that corresponds to a category index page.
+  for (let p = getPathDir(urlpath); p !== "/"; p = getPathDir(p)) {
+    if (sectionIndexMap.has(p)) {
+      return sectionIndexMap.get(p);
+    }
+  }
+  return undefined;
+};


### PR DESCRIPTION
Closes #121
Closes #64

Replace the default Docusaurus 404 component with one that is more helpful to docs users.

Add the following links to the 404 page so a user can find content similar to what they are looking for:

- A link to the nearest category index page, reducing the likelihood that a user needs to navigate through the docs sidebar tree manually. For example, a visit to `/docs/enroll-resources/blah` would result in a link to `/docs/enroll-resources/`.
- A link to any pages with the same slug as the 404ing page, in case we moved the page but did not provide a redirect.
- A link to the main docs home page.

This change also adds a search bar so the user can use what is often the most helpful tool for navigating to Teleport docs content.

Finally, this change adds a link to create a GitHub issue with the 404ing path so we can rectify any problems on our end.