### PR TITLE
Fix bug in rehype-hljs

### DIFF
--- a/server/fixtures/no-snippet-label-var.mdx
+++ b/server/fixtures/no-snippet-label-var.mdx
@@ -1,0 +1,5 @@
+- Single sign on URL: 
+   
+  ```
+  https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
+  ```

--- a/server/fixtures/result/no-snippet-label-var.html
+++ b/server/fixtures/result/no-snippet-label-var.html
@@ -1,0 +1,7 @@
+<ul>
+<li>
+<p>Single sign on URL:</p>
+<pre><code class="hljs"><span>https://</span><var name="example.teleport.sh:443"></var><span>/v1/webapi/saml/acs/okta
+</span></code></pre>
+</li>
+</ul>

--- a/server/fixtures/result/powershell-var.html
+++ b/server/fixtures/result/powershell-var.html
@@ -1,2 +1,2 @@
-<pre><span class="hljs language-powershell">certutil -dspublish -f </span><var name="user-ca.cer"></var><span class="hljs language-powershell"> NTAuthCA
-</span></pre>
+<pre><code class="hljs language-powershell"><span>certutil -dspublish -f </span><var name="user-ca.cer"></var><span> NTAuthCA
+</span></code></pre>

--- a/server/fixtures/result/text-snippet-label-var.html
+++ b/server/fixtures/result/text-snippet-label-var.html
@@ -1,0 +1,7 @@
+<ul>
+<li>
+<p>Single sign on URL:</p>
+<pre><code class="hljs language-text"><span>https://</span><var name="example.teleport.sh:443"></var><span>/v1/webapi/saml/acs/okta
+</span></code></pre>
+</li>
+</ul>

--- a/server/fixtures/text-snippet-label-var.mdx
+++ b/server/fixtures/text-snippet-label-var.mdx
@@ -1,0 +1,5 @@
+- Single sign on URL: 
+   
+  ```text
+  https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
+  ```

--- a/server/rehype-hljs.test.ts
+++ b/server/rehype-hljs.test.ts
@@ -12,7 +12,7 @@ import remarkParse from "remark-parse";
 import rehypeStringify from "rehype-stringify";
 import { definer as hcl } from "highlightjs-terraform";
 
-describe("server/remark-hljs-var", () => {
+describe("server/rehype-hljs-var", () => {
   // transformer executes remark and rehype plugins to transform a VFile using
   // rehypeHLJS. It uses legacy logic from gravitational/docs.
   // TODO: Use an approach that more closely reflects the remark/rehype execution
@@ -139,8 +139,42 @@ describe("server/remark-hljs-var", () => {
     expect((result.value as string).trim()).toBe(
       readFileSync(
         resolve("server/fixtures/result/hcl-addr-var.html"),
-        "utf-8"
-      ).trim()
+        "utf-8",
+      ).trim(),
+    );
+  });
+
+  test("Vars and text snippet label", () => {
+    const result = transformer({
+      value: readFileSync(
+        resolve("server/fixtures/text-snippet-label-var.mdx"),
+        "utf-8",
+      ),
+      path: "/docs/index.mdx",
+    });
+
+    expect((result.value as string).trim()).toBe(
+      readFileSync(
+        resolve("server/fixtures/result/text-snippet-label-var.html"),
+        "utf-8",
+      ).trim(),
+    );
+  });
+
+  test("Vars and no snippet label", () => {
+    const result = transformer({
+      value: readFileSync(
+        resolve("server/fixtures/no-snippet-label-var.mdx"),
+        "utf-8",
+      ),
+      path: "/docs/index.mdx",
+    });
+
+    expect((result.value as string).trim()).toBe(
+      readFileSync(
+        resolve("server/fixtures/result/no-snippet-label-var.html"),
+        "utf-8",
+      ).trim(),
     );
   });
 });


### PR DESCRIPTION
Closes #218

In the predecessor to the `rehype-hljs` plugin within the `gravitational/docs` repo, gravitational/docs#506 addressed an unanticipated aspect of the HTML AST within a code snippet by branching between different kinds of nodes.

However, this branching was not applied throughout the plugin, meaning that in some cases, the plugin mistakenly removes the `code` element that is the child of a `pre` element.

The copy button in our swizzled Docusaurus `Pre` component copies text in a code snippet by querying the `.hljs` class, which our syntax highlighting library adds to `code` elements. As a result, in cases where the plugin removes the `code` element, it makes the copy button nonfunctional.

This change edits the `rehype-hljs` plugin to branch on attributes of a node when modifying the final AST--a step neglected in gravitational/docs#506--avoiding the `code` removals. It also stops the plugin from adding the `hljs` class to `span`s, since this class is only supposed to modify `code` tags. This prevents the copy button from copying snippet values twice.