### PR TITLE
deps: remove rspack override

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
   "simple-git-hooks": {
     "pre-commit": "yarn lint-staged"
   },
-  "resolutions": {
-    "@rspack/core": "1.2.5"
-  },
   "dependencies": {
     "@csstools/postcss-global-data": "^2.1.1",
     "@docusaurus/core": "^3.8.0",


### PR DESCRIPTION
Forgot about the override that we added before, it's not needed anymore because docusaurus released new version:
- https://github.com/gravitational/docs-website/pull/231