### PR TITLE
Fix TabItem `value` assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "highlightjs-terraform": "https://github.com/highlightjs/highlightjs-terraform#eb1b9661e143a43dff6b58b391128ce5cdad31d4",
     "lowlight": "^3.1.0",
     "mdast-util-from-markdown": "^2.0.1",
-    "nanoid": "^5.1.0",
     "postcss-preset-env": "^10.2.0",
     "prism-react-renderer": "^2.3.0",
     "raw-loader": "^4.0.2",

--- a/src/theme/Tabs/index.tsx
+++ b/src/theme/Tabs/index.tsx
@@ -2,7 +2,7 @@ import React, { type ReactNode } from "react";
 import Tabs from "@theme-original/Tabs";
 import type TabsType from "@theme/Tabs";
 import type { WrapperProps } from "@docusaurus/types";
-import { nanoid } from "nanoid";
+import { useId } from "react";
 
 type Props = WrapperProps<typeof TabsType>;
 
@@ -28,7 +28,7 @@ export default function TabsWrapper(props: Props): ReactNode {
         ...child,
         props: {
           ...child.props,
-          value: nanoid(),
+          value: useId(),
         },
       };
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10598,11 +10598,6 @@ nanoid@^3.3.11:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
-nanoid@^5.1.0:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
-  integrity sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
Fixes #200

The current `TabItem` wrapper uses `nanoid` to assign a random value to the `value` property, which is what we did at the AST level prior to the changes in #183. This change uses `useId` instead, which is the idiomatic React technique for achieving a similar result. This approach also avoids the issue in #200.