### PR TITLE
Updating headers to use Lato

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@ body {
   padding: 0;
 }
 
-body {
+h1, h2, h3, h4, h5, h6, body {
   font-family: var(--font-base);
 }
 


### PR DESCRIPTION
The headers (h1 - h6) are defaulting to the system default, but are supposed to be using Lato. This PR updates the stylesheet for the headers to use Lato (font-base). 