### PR TITLE
Adding prefixIds so no SVG ID conflict

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -173,7 +173,18 @@ const config: Config = {
     ],
     "@docusaurus/theme-classic",
     "@docusaurus/plugin-sitemap",
-    "@docusaurus/plugin-svgr",
+    [
+      "@docusaurus/plugin-svgr",
+      {
+        svgrConfig: {
+          svgoConfig: {
+            plugins: [
+              "prefixIds"
+            ],
+          },
+        },
+      }
+    ],
     [
       "@docusaurus/plugin-content-docs",
       {


### PR DESCRIPTION
In preparing to add the TileRow component of SVGs to a markdown page I could not get the EC2 svg to show. Looking into it I noticed that the docusaurus plugin-svgr transforms svg files into React components at build time. The SVGs themselves have IDs but when plugin-svgr transforms them into React components, these get replaced with all the same IDs (#a)

![Screenshot 2025-06-18 at 1 43 02 PM](https://github.com/user-attachments/assets/e4e85fcf-35b2-48fa-8bf6-eb7aac51b4df)

When there are multiple vectors, inline, on a page, this causes a conflict or unstable behavior. 

We are already using the docusaurus svgr plugin. This includes SVGO, and SVGO has a plugin called prefixIds that 

> Prefix element IDs and class names with the filename or another arbitrary string. This is useful for reducing the likeliness of ID conflicts when multiple vectors are inlined into the same document. - [LINK](https://svgo.dev/docs/plugins/prefixIds/)

This PR adds the prefixIDs plugin which prefixes with the file name + svg + the original ID of the SVG. It idoesn't get removed and replaced with conflicting, similarIds, it gets prefixed and the original ID added on.  It will look like this:

![Screenshot 2025-06-18 at 2 38 57 PM](https://github.com/user-attachments/assets/81cde435-2075-497e-960a-fbae2963530e)

**Note**: This [doc](https://react-svgr.com/docs/options/) says that SVGR already implicitly enables the prefixIds SVGO plugin. It looks like all SVGs that are added to src tags in images are being prefixed, but standalone <svg, as in the [Icon component](https://github.com/gravitational/docs-website/blob/main/src/components/Icon/Icon.tsx), only seem to get processed when prefixIds is explicitly stated in the config based on testing (along with the same action as before with src based SVGs).  

More reading
- [plugin-svgr](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-svgr)
- [SVGO](https://github.com/svg/svgo/?tab=readme-ov-file)
- [prefixIDs](https://svgo.dev/docs/plugins/prefixIds/)



