### PR TITLE
Lint required frontmatter fields

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -2,14 +2,13 @@ import { resolve } from "path";
 import remarkVariables from "./.remark-build/server/remark-variables.mjs";
 import remarkIncludes from "./.remark-build/server/remark-includes.mjs";
 import { remarkLintTeleportDocsLinks } from "./.remark-build/server/lint-teleport-docs-links.mjs";
+import { remarkLintFrontmatter } from "./.remark-build/server/lint-frontmatter.mjs";
 import {
   getVersion,
   getVersionRootPath,
 } from "./.remark-build/server/docs-helpers.mjs";
 import { loadConfig } from "./.remark-build/server/config-docs.mjs";
-import {
-  updatePathsInIncludes,
-} from "./.remark-build//server/asset-path-helpers.mjs";
+import { updatePathsInIncludes } from "./.remark-build//server/asset-path-helpers.mjs";
 
 const configFix = {
   settings: {
@@ -49,6 +48,7 @@ const configLint = {
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
     ["lint-no-file-name-irregular-characters", false],
+    [remarkLintFrontmatter],
     [
       remarkIncludes, // Lints (!include.ext!) syntax
       {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "rehype-highlight": "^7.0.2",
     "remark-mdx": "^2.1.1",
     "remark-parse": "^10.0.1",
-    "vite-node": "^3.2.4"
+    "vite-node": "^3.2.4",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",

--- a/server/lint-frontmatter.test.ts
+++ b/server/lint-frontmatter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "@jest/globals";
+import { remarkLintFrontmatter } from "./lint-frontmatter";
+import { VFile } from "vfile";
+import { remark } from "remark";
+import mdx from "remark-mdx";
+import remarkFrontmatter from "remark-frontmatter";
+
+const getReasons = (value: string) => {
+  return (
+    remark()
+      .use(mdx as any)
+      // remark-frontmatter is a requirement for using this plugin
+      .use(remarkFrontmatter as any)
+      .use(remarkLintFrontmatter as any)
+      .processSync(new VFile({ value, path: "mypath.mdx" }) as any)
+      .messages.map((m) => m.reason)
+  );
+};
+
+describe("server/lint-frontmatter", () => {
+  interface testCase {
+    description: string;
+    input: string;
+    expected: Array<string>;
+  }
+
+  const testCases: Array<testCase> = [
+    {
+      description: "no product",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+type: how-to
+---
+`,
+      expected: ['missing frontmatter field "product"'],
+    },
+    {
+      description: "no type",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+product: identity-governance
+---
+`,
+      expected: ['missing frontmatter field "type"'],
+    },
+    {
+      description: "no product or type",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+---
+`,
+      expected: [
+        'missing frontmatter field "type"',
+        'missing frontmatter field "product"',
+      ],
+    },
+    {
+      description: "invalid product",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+product: "id-gov"
+type: "how-to"
+---
+`,
+      expected: [
+        'the "product" frontmatter field must be one of: identity-governance, identity-security, mwi, zero-trust, platform-wide',
+      ],
+    },
+    {
+      description: "invalid type",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+product: "mwi"
+type: "architecture"
+---
+`,
+      expected: [
+        'the "type" frontmatter field must be one of: how-to, conceptual, get-started, reference, faq, other',
+      ],
+    },
+    {
+      description: "valid case",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+product: "mwi"
+type: "how-to"
+---
+`,
+      expected: [],
+    },
+    {
+      description: "no frontmatter detected",
+      // The frontmatter document starts one line too low
+      input: `
+---
+title: "My page"
+description: "Provides documentation."
+product: "mwi"
+type: "how-to"
+---
+`,
+      expected: [
+        `the page must begin with a YAML frontmatter document surrounded by "---" separators`,
+      ],
+    },
+  ];
+
+  test.each(testCases)("$description", (tc) => {
+    expect(getReasons(tc.input)).toEqual(tc.expected);
+  });
+});

--- a/server/lint-frontmatter.test.ts
+++ b/server/lint-frontmatter.test.ts
@@ -30,66 +30,73 @@ describe("server/lint-frontmatter", () => {
       input: `---
 title: "My page"
 description: "Provides documentation."
-type: how-to
+labels:
+  - how-to
 ---
 `,
-      expected: ['missing frontmatter field "product"'],
+      expected: [],
     },
     {
       description: "no type",
       input: `---
 title: "My page"
 description: "Provides documentation."
-product: identity-governance
+labels: 
+ - identity-governance
 ---
 `,
-      expected: ['missing frontmatter field "type"'],
-    },
-    {
-      description: "no product or type",
-      input: `---
-title: "My page"
-description: "Provides documentation."
----
-`,
-      expected: [
-        'missing frontmatter field "type"',
-        'missing frontmatter field "product"',
-      ],
-    },
-    {
-      description: "invalid product",
-      input: `---
-title: "My page"
-description: "Provides documentation."
-product: "id-gov"
-type: "how-to"
----
-`,
-      expected: [
-        'the "product" frontmatter field must be one of: identity-governance, identity-security, mwi, zero-trust, platform-wide',
-      ],
-    },
-    {
-      description: "invalid type",
-      input: `---
-title: "My page"
-description: "Provides documentation."
-product: "mwi"
-type: "architecture"
----
-`,
-      expected: [
-        'the "type" frontmatter field must be one of: how-to, conceptual, get-started, reference, faq, other',
-      ],
+      expected: [],
     },
     {
       description: "valid case",
       input: `---
 title: "My page"
 description: "Provides documentation."
-product: "mwi"
-type: "how-to"
+labels:
+  - mwi
+  - how-to
+---
+`,
+      expected: [],
+    },
+    {
+      description: "arbitrary tags",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+labels:
+  - mwi
+  - how-to
+  - arbitrary
+  - new
+---
+`,
+      expected: [
+        "unrecognized label values: arbitrary, new - valid labels are: identity-governance, identity-security, mwi, zero-trust, platform-wide, how-to, conceptual, get-started, reference, faq",
+      ],
+    },
+    {
+      description: "multiple products",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+labels:
+  - how-to
+  - identity-security
+  - identity-governance
+---
+`,
+      expected: [],
+    },
+    {
+      description: "multiple guide types",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+labels:
+  - how-to
+  - reference
+  - identity-security
 ---
 `,
       expected: [],
@@ -107,6 +114,29 @@ type: "how-to"
 `,
       expected: [
         `the page must begin with a YAML frontmatter document surrounded by "---" separators`,
+      ],
+    },
+    {
+      description: "no labels field",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+---
+`,
+      expected: [
+        'every docs page must include a frontmatter field called "labels"',
+      ],
+    },
+    {
+      description: "labels field is not a list",
+      input: `---
+title: "My page"
+description: "Provides documentation."
+labels: label
+---
+`,
+      expected: [
+        'the "labels" frontmatter field must be a list with at least one value',
       ],
     },
   ];

--- a/server/lint-frontmatter.ts
+++ b/server/lint-frontmatter.ts
@@ -1,0 +1,58 @@
+import { lintRule } from "unified-lint-rule";
+import { visit } from "unist-util-visit";
+import type { Node } from "unist";
+import { parse } from "yaml";
+import type { Literal } from "mdast";
+
+const possibleProducts = [
+  "identity-governance",
+  "identity-security",
+  "mwi",
+  "zero-trust",
+  "platform-wide",
+];
+
+const possibleTypes = [
+  "how-to",
+  "conceptual",
+  "get-started",
+  "reference",
+  "faq",
+  "other",
+];
+
+export const remarkLintFrontmatter = lintRule(
+  "remark-lint:frontmatter",
+  (root: Node, vfile) => {
+    let hasFrontmatter = false;
+
+    visit(root, "yaml", (node: Node) => {
+      hasFrontmatter = true;
+
+      const frontmatter = parse((node as Literal).value);
+      if (!frontmatter.hasOwnProperty("type")) {
+        vfile.message(`missing frontmatter field "type"`, node.position);
+      } else if (!possibleTypes.includes(frontmatter.type)) {
+        vfile.message(
+          `the "type" frontmatter field must be one of: ${possibleTypes.join(", ")}`,
+          node.position,
+        );
+      }
+
+      if (!frontmatter.hasOwnProperty("product")) {
+        vfile.message(`missing frontmatter field "product"`, node.position);
+      } else if (!possibleProducts.includes(frontmatter.product)) {
+        vfile.message(
+          `the "product" frontmatter field must be one of: ${possibleProducts.join(", ")}`,
+          node.position,
+        );
+      }
+    });
+    if (!hasFrontmatter) {
+      vfile.message(
+        `the page must begin with a YAML frontmatter document surrounded by "---" separators`,
+        root.position,
+      );
+    }
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15370,6 +15370,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"


### PR DESCRIPTION
Require a `product` field and `type` field. We will use this to ensure that every docs page specifies the Teleport product it belongs to (e.g., Identity Governance) and the kind of guide it is (e.g., how-to guide). We plan to use these fields to create custom views of pages in the docs that match a particular category or combination of categories.