### PR TITLE
gha(amplify-preview): update amplify preview to v0.0.2

### DIFF
--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -21,7 +21,7 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Get Amplify Preview URL
-      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.2
+      uses: gravitational/shared-workflows/tools/amplify-preview@664e788d45a7f56935cf63094b4fb52a41b12015 # tools/amplify-preview/v0.0.2
       id: amplify_preview
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -28,7 +28,7 @@ jobs:
         create_branches: "false"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
-        wait_interval: 1s
+        wait_interval: 60s
 
 
     - name: Print failure message

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -29,7 +29,10 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
 
-    - run: echo ${{ steps.amplify_preview.outputs }}
+    - run: |
+        echo ${{ steps.amplify_preview.outputs.amplify_branch_name }}
+        echo ${{ steps.amplify_preview.outputs.amplify_app_id }}
+        echo ${{ steps.amplify_preview.outputs.amplify_job_id }}
 
   # If the event is merge_group, we want to make sure the build passes with the
   # most recent version of the docs content to prevent unexpected inputs from

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -22,11 +22,14 @@ jobs:
 
     - name: Get Amplify Preview URL
       uses: gravitational/shared-workflows/tools/amplify-preview@taras/amplify-github-outputs
+      id: amplify_preview
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
         create_branches: "false"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
+
+    - run: echo ${{ steps.amplify_preview.outputs }}
 
   # If the event is merge_group, we want to make sure the build passes with the
   # most recent version of the docs content to prevent unexpected inputs from

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -30,7 +30,7 @@ jobs:
         wait: "true"
         wait_interval: 1s
 
-    - if: always()
+    - if: failure()
       run: |
         echo ${{ steps.amplify_preview.outputs.amplify_branch_name }}
         echo ${{ steps.amplify_preview.outputs.amplify_app_id }}

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -30,7 +30,8 @@ jobs:
         wait: "true"
         wait_interval: 1s
 
-    - run: |
+    - if: always()
+      run: |
         echo ${{ steps.amplify_preview.outputs.amplify_branch_name }}
         echo ${{ steps.amplify_preview.outputs.amplify_app_id }}
         echo ${{ steps.amplify_preview.outputs.amplify_job_id }}

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -21,7 +21,7 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Get Amplify Preview URL
-      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.1
+      uses: gravitational/shared-workflows/tools/amplify-preview@taras/amplify-github-outputs
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
         create_branches: "false"

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -28,6 +28,7 @@ jobs:
         create_branches: "false"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
+        wait_interval: 1s
 
     - run: |
         echo ${{ steps.amplify_preview.outputs.amplify_branch_name }}

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -21,7 +21,7 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Get Amplify Preview URL
-      uses: gravitational/shared-workflows/tools/amplify-preview@taras/amplify-github-outputs
+      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.2
       id: amplify_preview
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
@@ -30,11 +30,17 @@ jobs:
         wait: "true"
         wait_interval: 1s
 
-    - if: failure()
+
+    - name: Print failure message
+      if: failure()
+      env:
+        ERR_TITLE: Teleport Docs preview build failed
+        ERR_MESSAGE: >-
+          Please refer to the following documentation for help: https://www.notion.so/goteleport/How-to-Amplify-deployments-162fdd3830be8096ba72efa1a49ee7bc?pvs=4.
+          Execution info: ${{ steps.amplify_preview.outputs.amplify_app_id }} ${{ steps.amplify_preview.outputs.amplify_branch_name }} ${{ steps.amplify_preview.outputs.amplify_job_id }}
       run: |
-        echo ${{ steps.amplify_preview.outputs.amplify_branch_name }}
-        echo ${{ steps.amplify_preview.outputs.amplify_app_id }}
-        echo ${{ steps.amplify_preview.outputs.amplify_job_id }}
+        echo ::error title=$ERR_TITLE::$ERR_MESSAGE
+        exit 1
 
   # If the event is merge_group, we want to make sure the build passes with the
   # most recent version of the docs content to prevent unexpected inputs from


### PR DESCRIPTION
### Summary

This updates `amplify-preview` action (https://github.com/gravitational/shared-workflows/pull/311) to improve following errors:
- Fail workflow execution if amplify job failed with timeout. This will block PR from being merged if preview wasn't generated properly. In case of build timeout workflow can be restarted manually.
- Increase retry interval to once per minute. This will result in total wait time of 40m.
- Add better message which points to the notion page on how to debug the problem

### Testing

Failing job example: https://github.com/gravitational/docs-website/actions/runs/16122341243/job/45491022486