### PR TITLE
Add a remark linter for "How it works" H2s

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -6,10 +6,9 @@ import {
   getVersion,
   getVersionRootPath,
 } from "./.remark-build/server/docs-helpers.mjs";
+import { remarkLintPageStructure } from "./.remark-build/server/lint-page-structure.mjs";
 import { loadConfig } from "./.remark-build/server/config-docs.mjs";
-import {
-  updatePathsInIncludes,
-} from "./.remark-build//server/asset-path-helpers.mjs";
+import { updatePathsInIncludes } from "./.remark-build//server/asset-path-helpers.mjs";
 
 const configFix = {
   settings: {
@@ -71,6 +70,7 @@ const configLint = {
     // [CM-08 Information System Component Inventory]((=fedramp.control_url=)CM-8)
     ["validate-links", { repository: false }],
     [remarkLintTeleportDocsLinks],
+    [remarkLintPageStructure],
     // Disabling the remarkLintFrontmatter check until we fix
     // gravitational/docs#80
     // [remarkLintFrontmatter, ["error"]],

--- a/server/lint-page-structure.test.ts
+++ b/server/lint-page-structure.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "@jest/globals";
+import { VFile } from "vfile";
+import { remark } from "remark";
+import mdx from "remark-mdx";
+import remarkFrontmatter from "remark-frontmatter";
+import { remarkLintPageStructure } from "./lint-page-structure";
+
+const getReasons = (value: string) => {
+  return (
+    remark()
+      .use(mdx as any)
+      // remark-frontmatter is a requirement for using this plugin
+      .use(remarkFrontmatter as any)
+      .use(remarkLintPageStructure as any)
+      .processSync(new VFile({ value, path: "mypath.mdx" }) as any)
+      .messages.map((m) => m.reason)
+  );
+};
+
+describe("server/lint-page-structure", () => {
+  describe('linting "How it works" H2s in how-to guides', () => {
+    interface testCase {
+      description: string;
+      input: string;
+      expected: Array<string>;
+    }
+
+    const testCases: Array<testCase> = [
+      {
+        description: `missing "How it works" section in a how-to guide`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Step 1/1. Install Teleport
+
+This step shows you how to install Teleport.
+`,
+        expected: [
+          "In a how-to guide, the first H2-level section must be called `## How it works`. Use this section to include 1-3 paragraphs that describe the high-level architecture of the setup shown in the guide.",
+        ],
+      },
+      {
+        description: `"How it works" is not the first section`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## How it works
+
+Here is architectural information
+
+## Step 1/1. Install Teleport
+
+This step shows you how to install Teleport.
+`,
+        expected: [
+          "In a how-to guide, the first H2-level section must be called `## How it works`. Use this section to include 1-3 paragraphs that describe the high-level architecture of the setup shown in the guide.",
+        ],
+      },
+      {
+        description: `valid "How it works" section in a how-to guide`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+## How it works
+
+Here is architectural information.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Step 1/1. Install Teleport
+
+This step shows you how to install Teleport.
+`,
+        expected: [],
+      },
+      {
+        description: `missing "How it works" section in a non-how-to guide`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Concepts
+
+Here's some conceptual information.
+`,
+        expected: [],
+      },
+    ];
+
+    test.each(testCases)("$description", (tc) => {
+      expect(getReasons(tc.input)).toEqual(tc.expected);
+    });
+  });
+
+  describe("linting step numbering", () => {
+    interface testCase {
+      description: string;
+      input: string;
+      expected: Array<string>;
+    }
+
+    const testCases: Array<testCase> = [
+      {
+        description: "missing steps",
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+Introduction.
+
+## How it works
+
+How it works
+
+## Prerequisites
+
+Some requirements
+
+## Step 1/3.
+
+Step 1 instructions
+
+## Step 3/3.
+
+Step 3 instructions
+`,
+        expected: [
+          `this guide has an incorrect sequence of steps - expecting a section called "## Step 1/2."`,
+          `this guide has an incorrect sequence of steps - expecting a section called "## Step 2/2."`,
+        ],
+      },
+      {
+        description: "inconsistent step denominators",
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+Introduction.
+
+## How it works
+
+How it works
+
+## Prerequisites
+
+Some requirements
+
+## Step 1/3.
+
+Step 1 instructions
+
+## Step 2/4.
+
+Step 2 instructions.
+
+## Step 3/3.
+
+Step 3 instructions
+`,
+        expected: [
+          `this guide has an incorrect sequence of steps - expecting a section called "## Step 2/3."`,
+        ],
+      },
+      {
+        description: "valid step numbering",
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+Introduction.
+
+## How it works
+
+How it works
+
+## Prerequisites
+
+Some requirements
+
+## Step 1/3.
+
+Step 1 instructions
+
+## Step 2/3.
+
+Step 2 instructions.
+
+## Step 3/3.
+
+Step 3 instructions
+`,
+        expected: [],
+      },
+    ];
+
+    test.each(testCases)("$description", (tc) => {
+      expect(getReasons(tc.input)).toEqual(tc.expected);
+    });
+  });
+});

--- a/server/lint-page-structure.ts
+++ b/server/lint-page-structure.ts
@@ -1,0 +1,63 @@
+import { lintRule } from "unified-lint-rule";
+import { visit } from "unist-util-visit";
+import type { Heading, Text } from "mdast";
+import type { EsmNode, MdxAnyElement, MdxastNode } from "./types-unist";
+import type { Node, Position } from "unist";
+
+const mdxNodeTypes = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
+
+interface stepNumber {
+  numerator: number;
+  denominator: number;
+  position: Position;
+}
+
+const stepNumberPattern = `^Step ([0-9]+)/([0-9]+)`;
+
+export const remarkLintPageStructure = lintRule(
+  "remark-lint:page-structure",
+  (root: Node, vfile) => {
+    const h2s: Array<Text> = [];
+    visit(root, undefined, (node: Node) => {
+      const hed = node as Heading;
+      if (hed.type == "heading" && hed.depth == 2) {
+        // A Heading as parsed by remark-mdx only has a single child, the
+        // heading text.
+        h2s.push(hed.children[0] as Text);
+      }
+    });
+
+    const hasStep = h2s.some((h) => h.value.match(/^Step [0-9]/) !== null);
+    if (hasStep && h2s[0].value !== "How it works") {
+      vfile.message(
+        "In a how-to guide, the first H2-level section must be called `## How it works`. Use this section to include 1-3 paragraphs that describe the high-level architecture of the setup shown in the guide.",
+        h2s[0].position,
+      );
+    }
+    const stepNumbers: Array<stepNumber> = [];
+    h2s.forEach((heading) => {
+      const parts = heading.value.match(stepNumberPattern);
+      if (parts !== null) {
+        stepNumbers.push({
+          numerator: parseInt(parts[1]),
+          denominator: parseInt(parts[2]),
+          position: heading.position,
+        });
+      }
+    });
+
+    const expectedDenominator = stepNumbers.length;
+    for (let i = 0; i < stepNumbers.length; i++) {
+      const expectedNumerator = i + 1;
+      if (
+        stepNumbers[i].numerator !== expectedNumerator ||
+        stepNumbers[i].denominator !== expectedDenominator
+      ) {
+        vfile.message(
+          `this guide has an incorrect sequence of steps - expecting a section called "## Step ${expectedNumerator}/${expectedDenominator}."`,
+          stepNumbers[i].position,
+        );
+      }
+    }
+  },
+);


### PR DESCRIPTION
See #204

We use a Vale linter to enforce the presence of a "How it works" H2 in how-to guides, making sure that these guides begin with an architectural overview so users can form a mental model of the procedure before they begin to follow it. (Otherwise, how-to guides read as a plunge into unknown depths.)

This change turns the Vale "How it works" linter into a remark linter. This way, docs pages can add a comment directive to ignore the linter. While Vale linters also support comment directives, these only apply to linters with scopes besides `raw`, since the `raw` scope operates on text and Vale comment directives operate on a parsed AST. The "How it works" Vale linter requires the `raw` scope in order to examine headings. By changing this to a `remark` linter, we can examine headings while also allowing `lint ignore` comment directives.