### PR TITLE
Emit a build error on duplicate redirect sources

### DIFF
--- a/server/redirects.test.ts
+++ b/server/redirects.test.ts
@@ -1,78 +1,105 @@
 import { describe, expect, test } from "@jest/globals";
-import { CustomRedirect, validateRedirect } from "./redirects";
+import { CustomRedirect, validateRedirects } from "./redirects";
 
 describe("validateRedirects", () => {
   interface testCase {
     description: string;
-    input: CustomRedirect;
+    input: Array<CustomRedirect>;
     shouldThrow: boolean;
     errorSubstring: string;
   }
   const testCases: Array<testCase> = [
     {
       description: "incorrect index page source",
-      input: {
-        source: "/enroll-resources/applications/applications/",
-        destination: "/enroll-resources/apps/",
-        permanent: true,
-      },
+      input: [
+        {
+          source: "/enroll-resources/applications/applications/",
+          destination: "/enroll-resources/apps/",
+          permanent: true,
+        },
+      ],
       shouldThrow: true,
       errorSubstring:
         "redirect source includes an incorrect category index page path - remove the final path segment: /enroll-resources/applications/applications/",
     },
     {
       description: "incorrect index page destination",
-      input: {
-        source: "/enroll-resources/apps/",
-        destination: "/enroll-resources/applications/applications/",
-        permanent: true,
-      },
+      input: [
+        {
+          source: "/enroll-resources/apps/",
+          destination: "/enroll-resources/applications/applications/",
+          permanent: true,
+        },
+      ],
       shouldThrow: true,
       errorSubstring:
         "redirect destination includes an incorrect category index page path - remove the final path segment: /enroll-resources/applications/applications/",
     },
     {
       description: "no leading slash in a source",
-      input: {
-        source: "enroll-resources/apps/",
-        destination: "/enroll-resources/applications/applications/",
-        permanent: true,
-      },
+      input: [
+        {
+          source: "enroll-resources/apps/",
+          destination: "/enroll-resources/applications/applications/",
+          permanent: true,
+        },
+      ],
       shouldThrow: true,
       errorSubstring:
         "redirect source must start with a trailing slash: enroll-resources/apps/",
     },
     {
       description: "no leading slash in a destination",
-      input: {
-        source: "/enroll-resources/apps/",
-        destination: "enroll-resources/applications/applications/",
-        permanent: true,
-      },
+      input: [
+        {
+          source: "/enroll-resources/apps/",
+          destination: "enroll-resources/applications/applications/",
+          permanent: true,
+        },
+      ],
       shouldThrow: true,
       errorSubstring:
         "redirect destination includes an incorrect category index page path - remove the final path segment: enroll-resources/applications/applications/",
     },
     {
       description: "valid case",
-      input: {
-        source: "/enroll-resources/apps/",
-        destination: "/enroll-resources/applications/",
-        permanent: true,
-      },
+      input: [
+        {
+          source: "/enroll-resources/apps/",
+          destination: "/enroll-resources/applications/",
+          permanent: true,
+        },
+      ],
       shouldThrow: false,
       errorSubstring: "",
+    },
+    {
+      description: "multiple redirects with the same source",
+      input: [
+        {
+          source: "/enroll-resources/apps/",
+          destination: "/enroll-resources/applications/",
+          permanent: true,
+        },
+        {
+          source: "/enroll-resources/apps/",
+          destination: "/enroll-resources/apps/",
+          permanent: true,
+        },
+      ],
+      shouldThrow: true,
+      errorSubstring: "same source",
     },
   ];
 
   test.each(testCases)("$description", (c) => {
     if (c.shouldThrow) {
       expect(() => {
-        validateRedirect(c.input);
+        validateRedirects(c.input);
       }).toThrow(c.errorSubstring);
     } else {
       expect(() => {
-        validateRedirect(c.input);
+        validateRedirects(c.input);
       }).not.toThrow();
     }
   });

--- a/server/redirects.ts
+++ b/server/redirects.ts
@@ -18,7 +18,21 @@ const isIndexPage = (urlpath: string): boolean => {
   );
 };
 
-export const validateRedirect = (redirect: CustomRedirect) => {
+export const validateRedirects = (redirects: Array<CustomRedirect>) => {
+  const sources = new Map();
+  redirects.forEach((r) => {
+    if (!sources.has(r.source)) {
+      sources.set(r.source, true);
+    } else {
+      throw new Error(
+        `there are multiple redirects with the same source: ${r.source}`,
+      );
+    }
+    validateRedirect(r);
+  });
+};
+
+const validateRedirect = (redirect: CustomRedirect) => {
   ["source", "destination"].forEach((p) => {
     if (isIndexPage(redirect[p])) {
       throw new Error(
@@ -42,7 +56,7 @@ export const getRedirects = () => {
     return config.redirects || [];
   });
 
-  result.forEach(validateRedirect);
+  validateRedirects(result as Array<CustomRedirect>);
   return result.map((r) => {
     return {
       from: r.source,


### PR DESCRIPTION
Duplicate redirect sources in Docusaurus do not interrupt a docs site build. However, they can have unpredictable results, and cause Docusaurus to print a warning message that can add clutter to build logs.

Edit the `getRedirects` function that we use to fetch redirects when evaluating the Docusaurus configuration file to throw an error if two redirects have the same source. This function already validates each redirect, so this change expands the validation logic to validate the redirect array as a whole.