### PR TITLE
Throw an error on an invalid Admonition type

### DIFF
--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -1,0 +1,21 @@
+import React, { type ReactNode } from "react";
+import Admonition from "@theme-original/Admonition";
+import type AdmonitionType from "@theme/Admonition";
+import type { WrapperProps } from "@docusaurus/types";
+import AdmonitionTypes from "@theme/Admonition/Types";
+
+type Props = WrapperProps<typeof AdmonitionType>;
+const allTypes = Object.keys(AdmonitionTypes).join(", ");
+
+export default function AdmonitionWrapper(props: Props): ReactNode {
+  if (!AdmonitionTypes.hasOwnProperty(props.type)) {
+    throw new Error(
+      `unexpected Admonition type: ${props.type} - available types are ${allTypes}`,
+    );
+  }
+  return (
+    <>
+      <Admonition {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
The default Docusaurus behavior when rendering an Admonition is to print a warning on an invalid type. This not only causes an unintended result to render on the docs site, it creates clutter when reading docs build output. Since Docusaurus build logs are not structured consistently, it is important to keep it clean for a human reader.