### PR TITLE
Revert "add noIndex: true for preview envs"

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -127,7 +127,6 @@ const config: Config = {
   // contain a trailing slash in the URL, so add trailing slashes to sitemap
   // URLs to prevent clients from receiving non-200 responses.
   trailingSlash: true,
-  noIndex: process.env.AWS_BRANCH_NAME !== "main",
 
   markdown: {
     parseFrontMatter: async (params) => {


### PR DESCRIPTION
Reverts gravitational/docs-website#287


I can see `noIndex` in prod for some reason. Reverting for now