### PR TITLE
Tile Style Modification

### DIFF
--- a/src/components/Icon/Icon.module.css
+++ b/src/components/Icon/Icon.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   display: block;
-  width: var(--size);
   height: var(--size);
+  width: auto;
 
   &.xxs {
     --size: 10px;

--- a/src/components/Tile/Tile.module.css
+++ b/src/components/Tile/Tile.module.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
+  padding: 10px;
   gap: 5px;
   width: 100%;
   min-height: 130px;


### PR DESCRIPTION
There are two small problems with the Tile component that this PR addresses.

First, the Icon component has only accounted for square icons. We had width and height set to matching variables. However, when we have a non-square icon, it shrinks the width to square levels making it way to small. Looks like this (see Cloud Providers).

<img width="832" height="342" alt="Screenshot 2025-08-14 at 2 21 03 PM" src="https://github.com/user-attachments/assets/e1b9ae83-1d89-4db8-a534-0548a159e9d8" />

Therefore, setting width to auto allows for height to still honor the icon size but the width to fall in proportion as seen here: 

<img width="836" height="347" alt="Screenshot 2025-08-14 at 2 20 38 PM" src="https://github.com/user-attachments/assets/18b71a6b-f15c-47fd-a782-f182fa52a9f9" />

Second, as seen in the previous screenshot, longer text is not being centered. Though the flex is right, the text is not wrapped in a div, it stands alone, so doesn't get centered. So I added `text-align: center` to fix. You'll also note that the longer text touches the edges of the Tiles. So I added a little padding as well.
