### PR TITLE
Fixes submenu navigation component in documentation navigation.

### DIFF
--- a/src/components/DropdownMenu/DropdownSubMenu.tsx
+++ b/src/components/DropdownMenu/DropdownSubMenu.tsx
@@ -22,7 +22,7 @@ const DropdownSubMenu = ({ items }: DropdownMenuProps) => {
           if (submenuTitle && submenuTitleLink?.length > 0) {
             return (
               <Link
-                href={submenuTitle}
+                href={submenuTitleLink}
                 className={styles.submenuLink}
                 key={`submenu-${submenuTitle}-${index}`}
               >


### PR DESCRIPTION
This change fixes the broken submenu navigation link in the docs site. It appears to be a typo that results in the Platform -> "Technology" submenu link. 

Before:
<img width="1708" height="1338" alt="image" src="https://github.com/user-attachments/assets/2761b9d1-11eb-41ab-a393-d65833496a28" />

After:
<img width="1708" height="1295" alt="image" src="https://github.com/user-attachments/assets/d058066f-329d-490f-b3e9-fe19619e53a7" />
