### PR TITLE
Add `noIndex=true` for all docs branches except the "main".

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -126,6 +126,8 @@ const config: Config = {
   favicon: "/favicon.svg",
   url: process.env.DOCUSAURUS_CONFIG_URL || "https://goteleport.com",
   baseUrl: process.env.DOCUSAURUS_CONFIG_BASE_URL || "/",
+  // configure "noIndex" for all branches except the "main"
+  noIndex: process.env.AWS_BRANCH !== "main",
   // Our hosting infrastructure redirects requests to a docs page that do not
   // contain a trailing slash in the URL, so add trailing slashes to sitemap
   // URLs to prevent clients from receiving non-200 responses.


### PR DESCRIPTION
This should prevent accidental indexing of non-prod branches by search engines.

Previous time (https://github.com/gravitational/docs-website/pull/287) this didn't work, because of wrong Amplify variable name (should be `AWS_BRANCH` and not `AWS_BRANCH_NAME`[^1])

[^1]: https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html

### Testing

Currently `dev` branch configured with `noIndex: false` for testing purposes (will be reverted once this is merged)
  - https://github.com/gravitational/docs-website/blob/4686358fceaee2c0ab57b59369855bb054d7a678/docusaurus.config.ts#L129


Comparing dev website and preview one:

```shell
$ curl -qs https://goteleport.dev/docs/ | grep -i noindex; echo $?
# nothing
1
```

```shell
 $ curl -qs https://taras-add-noindex-setting.d2mrezcly5gcqm.amplifyapp.com/docs/ | grep -i noindex; echo $?
...
<meta data-rh=true name=robots content="noindex, nofollow">
...
0
```



