### PR TITLE
Throw on broken Markdown links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -148,7 +148,7 @@ const config: Config = {
     },
   },
 
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
 
   i18n: {


### PR DESCRIPTION
Configure Docusaurus to throw on broken Markdown links instead of simply printing a warning to (a) prevent warning messages from cluttering build output and (b) prevent unexpected link behavior.