### PR TITLE
Adjust bottom padding for LandingHero and UseCasesList

### DIFF
--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -1,7 +1,7 @@
 .landingHero {
-  padding: var(--m-4) 0;
+  padding: var(-m-4) 0 var(--m-5) 0;
   @media (--md-scr) {
-    padding: var(--m-4) var(--m-3);
+    padding: var(--m-4) var(--m-3) var(--m-8) var(--m-3);
   }
 }
 

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
@@ -1,6 +1,10 @@
 .useCasesList {
-  padding-bottom: var(--m-4);
+  padding-bottom: var(--m-5);
   background-color: var(--color-white);
+
+  @media (--md-scr) {
+    padding-bottom: var(--m-8);
+  }
 }
 
 .title {


### PR DESCRIPTION
The space between sections on product landing pages should be 64px on desktop and 40px on mobile.