### PR TITLE
Remove the Google Analytics plugin

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -170,13 +170,6 @@ const config: Config = {
       },
     ],
     [
-      "@docusaurus/plugin-google-gtag",
-      {
-        trackingID: "G-Z1BMQRVFH3",
-        anonymizeIP: true,
-      },
-    ],
-    [
       "@docusaurus/plugin-google-tag-manager",
       {
         containerId: "GTM-WMR7H6",


### PR DESCRIPTION
Google Tag Manager embeds Google Analytics, so once we enable GTM for the docs site, there is no need for the gtag plugin.