### PR TITLE
Fix navigation category links

### DIFF
--- a/src/components/Menu/Category.tsx
+++ b/src/components/Menu/Category.tsx
@@ -14,21 +14,14 @@ import {
 
 import styles from "./Category.module.css";
 
-export interface MenuCategoryProps {
-  title: string;
-  link?: string;
-  type?: NavigationItem["type"];
-  testId?: string;
-  dropdownType?: NavigationItem["dropdownType"];
-  navSections?: NavigationItem["navSections"];
-  onClick?: () => void | undefined | Promise<void>;
-}
 
-interface MenuCategoryComponentProps extends MenuCategoryProps {
+interface MenuCategoryComponentProps extends NavigationItem {
   id: number;
   opened: boolean;
   onToggleOpened: (id: number | null) => void;
   onHover: (id: number | null) => void;
+  testId?: string;
+  onClick?: () => void | undefined | Promise<void>;
 }
 
 const MenuCategory = ({


### PR DESCRIPTION
## Changes
- Updated navigation menu category interface to extend the navigationitem type
- Corrected the menu category `url `prop to be `link` instead


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211163720294338