### PR TITLE
Declare box shadow values with variables

### DIFF
--- a/src/components/Pages/Homepage/DocsHeader/DocsHeader.module.css
+++ b/src/components/Pages/Homepage/DocsHeader/DocsHeader.module.css
@@ -63,7 +63,7 @@
   width: 100%;
   border-radius: var(--r-lg);
   background: var(--color-white);
-  box-shadow: 0 5px 20px 0 rgba(19, 19, 19, 0.1);
+  box-shadow: var(--lp-box-shadow);
   position: relative;
   overflow: visible;
   z-index: 1000;

--- a/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
@@ -55,7 +55,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 var(--lp-box-shadow-hover);
+      box-shadow: var(--lp-box-shadow-hover);
     }
   }
 
@@ -109,7 +109,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 var(--lp-box-shadow-hover);
+      box-shadow: var(--lp-box-shadow-hover);
       .linkTitle {
         color: var(--color-dark-purple);
       }

--- a/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
@@ -55,7 +55,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+      box-shadow: 0 var(--lp-box-shadow-hover);
     }
   }
 
@@ -109,7 +109,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+      box-shadow: 0 var(--lp-box-shadow-hover);
       .linkTitle {
         color: var(--color-dark-purple);
       }

--- a/src/components/Pages/Homepage/Integrations/Integrations.module.css
+++ b/src/components/Pages/Homepage/Integrations/Integrations.module.css
@@ -72,7 +72,7 @@
 
   &:hover {
     background: var(--color-white);
-    box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+    box-shadow: 0 var(--lp-box-shadow-hover);
   }
 }
 

--- a/src/components/Pages/Homepage/Integrations/Integrations.module.css
+++ b/src/components/Pages/Homepage/Integrations/Integrations.module.css
@@ -72,7 +72,7 @@
 
   &:hover {
     background: var(--color-white);
-    box-shadow: 0 var(--lp-box-shadow-hover);
+    box-shadow: var(--lp-box-shadow-hover);
   }
 }
 

--- a/src/components/Pages/Homepage/Products/Products.module.css
+++ b/src/components/Pages/Homepage/Products/Products.module.css
@@ -126,7 +126,7 @@
 
   &:hover {
     background: var(--color-white);
-    box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+    box-shadow: 0 var(--lp-box-shadow-hover);
   }
 }
 

--- a/src/components/Pages/Homepage/Products/Products.module.css
+++ b/src/components/Pages/Homepage/Products/Products.module.css
@@ -126,7 +126,7 @@
 
   &:hover {
     background: var(--color-white);
-    box-shadow: 0 var(--lp-box-shadow-hover);
+    box-shadow: var(--lp-box-shadow-hover);
   }
 }
 

--- a/src/components/Pages/Homepage/Resources/Resources.module.css
+++ b/src/components/Pages/Homepage/Resources/Resources.module.css
@@ -59,7 +59,7 @@ a.resourceItem {
   &:hover {
     background: var(--color-white);
     cursor: pointer;
-    box-shadow: 0 var(--lp-box-shadow-hover);
+    box-shadow: var(--lp-box-shadow-hover);
     text-decoration: none;
     .resourceTitle {
       color: var(--color-dark-purple);

--- a/src/components/Pages/Homepage/Resources/Resources.module.css
+++ b/src/components/Pages/Homepage/Resources/Resources.module.css
@@ -59,7 +59,7 @@ a.resourceItem {
   &:hover {
     background: var(--color-white);
     cursor: pointer;
-    box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+    box-shadow: 0 var(--lp-box-shadow-hover);
     text-decoration: none;
     .resourceTitle {
       color: var(--color-dark-purple);

--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -150,7 +150,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+      box-shadow: 0 var(--lp-box-shadow-hover);
       .linkTitle {
         color: var(--color-dark-purple);
       }

--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -150,7 +150,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: 0 var(--lp-box-shadow-hover);
+      box-shadow: var(--lp-box-shadow-hover);
       .linkTitle {
         color: var(--color-dark-purple);
       }

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
@@ -75,7 +75,7 @@
 a.item:hover {
   text-decoration: none;
   background: var(--color-white);
-  box-shadow: 0 4px 12px rgba(81, 47, 201, 0.15);
+  box-shadow: 0 var(--lp-box-shadow-hover);
   border-color: rgba(0, 0, 0, 0);
   h3 {
     color: var(--color-dark-purple);

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
@@ -75,7 +75,7 @@
 a.item:hover {
   text-decoration: none;
   background: var(--color-white);
-  box-shadow: 0 var(--lp-box-shadow-hover);
+  box-shadow: var(--lp-box-shadow-hover);
   border-color: rgba(0, 0, 0, 0);
   h3 {
     color: var(--color-dark-purple);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -117,6 +117,10 @@
   --lp-section-padding-lg: 84px;
   --lp-section-padding-md: 80px;
   --lp-section-padding-sm: 32px;
+
+  /* landing page component shadows */
+  --lp-box-shadow: 0 5px 20px 0 rgba(19, 19, 19, 0.1);
+  --lp-box-shadow-hover: 0 4px 12px rgba(81, 47, 201, 0.15);
 }
 
 @media (max-width: 996px) {


### PR DESCRIPTION
The `box-shadow` style properties in various landing page components were hard-coded. This PR adds two variables, `--lp-box-shadow` and `--lp-box-shadow-hover `which replace the hard-coded values.

Closes #329 