### PR TITLE
Use variable to declare max-width of landing page sections

### DIFF
--- a/src/components/Pages/Homepage/Integrations/Integrations.module.css
+++ b/src/components/Pages/Homepage/Integrations/Integrations.module.css
@@ -7,7 +7,7 @@
 
 .container {
   width: 100%;
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   padding: 0 1rem;
   margin: 0 auto;
 }

--- a/src/components/Pages/Homepage/Products/Products.module.css
+++ b/src/components/Pages/Homepage/Products/Products.module.css
@@ -1,7 +1,7 @@
 .products {
   padding-bottom: 5.25rem; /* 84px */
   background-color: var(--color-white);
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   margin: 0 auto;
 }
 

--- a/src/components/Pages/Homepage/Resources/Resources.module.css
+++ b/src/components/Pages/Homepage/Resources/Resources.module.css
@@ -1,7 +1,7 @@
 .resources {
   padding-bottom: 5.25rem; /* 84px */
   background-color: var(--color-white);
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   margin: 0 auto;
 }
 

--- a/src/components/Pages/Homepage/VersionHighlights/VersionHighlights.module.css
+++ b/src/components/Pages/Homepage/VersionHighlights/VersionHighlights.module.css
@@ -12,7 +12,7 @@
 }
 
 .container {
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   margin: 0 auto;
 }
 

--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -7,7 +7,7 @@
 
 .container {
   width: 100%;
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   margin: 0 auto;
 }
 

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
@@ -13,7 +13,7 @@
 }
 
 .container {
-  max-width: 1400px;
+  max-width: var(--lp-section-max-width);
   margin: 0 auto;
 }
 

--- a/src/theme/DocRoot/Layout/Main/styles.module.css
+++ b/src/theme/DocRoot/Layout/Main/styles.module.css
@@ -11,7 +11,7 @@
 
 :global(main.template-full-width) :global(.container) :global(.theme-doc-markdown) {
   > :global(:not(section)) {
-    max-width: 1400px;
+    max-width: var(--lp-section-max-width);
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
The `max-width` css property of landing page sections was hard-coded. This PR changes the components to use the `--lp-section-max-width`variable instead. Related to issue #326 