### PR TITLE
Switch .gitmodules.example URL schemes

### DIFF
--- a/.gitmodules.example
+++ b/.gitmodules.example
@@ -1,15 +1,15 @@
 [submodule "content/16.x"]
 	path = content/16.x
-	url = https://github.com/gravitational/teleport/
+	url = ssh://git@github.com/gravitational/teleport/
 	branch = branch/v16
 [submodule "content/17.x"]
 	path = content/17.x
-	url = https://github.com/gravitational/teleport/
+	url = ssh://git@github.com/gravitational/teleport/
 	branch = branch/v17
 [submodule "content/18.x"]
 	path = content/18.x
-	url = https://github.com/gravitational/teleport
+	url = ssh://git@github.com/gravitational/teleport
 	branch = branch/v18
 [submodule "content/19.x"]
 	path = content/19.x
-	url = https://github.com/gravitational/teleport
+	url = ssh://git@github.com/gravitational/teleport


### PR DESCRIPTION
Use SSH instead of HTTPS. While the docs build runner originally needed to use HTTPS when building the docs in production using git submodules, now that we only use subodules for local development, there is no need to use HTTPS.