### PR TITLE
Allow for configurable repo for archive downloads

### DIFF
--- a/scripts/download-content-archive.sh
+++ b/scripts/download-content-archive.sh
@@ -2,9 +2,12 @@
 set -o pipefail;
 # This script assumes that the name of each first-level child directory in
 # content is content/v<MAJOR_VERSION>.x, e.g., content/v17.x.
+#
 # $1 is the relative path of the content directory to the project root.
 # $2 is the name of the branch on GitHub from which to fetch an archive, e.g.,
 # master or branch/v17.
+# $3 is an optional repository path in <owner>/<name> format. the default is
+# gravitational/teleport
 
 if [[ -n $(find "$1" -name "docs") ]]; then
     echo "Content directory $1 already includes a docs directory. Skipping."
@@ -25,7 +28,16 @@ if [[ "$?" -ne 0 ]]; then
 fi
 echo "Found major version $MAJOR";
 
-BRANCH_TAR_URL="https://api.github.com/repos/gravitational/teleport/tarball/${2}"
+if [ -z "$3" ] || [ "$3" = "null" ]; then
+    REPO="gravitational/teleport";
+elif $(echo "$3" | grep -vqE "^[a-z-]+/[a-z-]+$"); then
+    echo "Invalid GitHub repo: $3. Must be of the format <owner>/<name>";
+    exit 1;
+else
+    REPO="$3";
+fi
+
+BRANCH_TAR_URL="https://api.github.com/repos/${REPO}/tarball/${2}"
 
 # Use curl's ETag support to compare the tarball we want to download with the one in the cache. 
 # Save the tarball as .downloads/$1.tar.gz

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -16,7 +16,8 @@ if [[ -n ${AWS_APP_ID} || -n ${CI} ]]; then
      mkdir -p "content/$v";
 
      BRANCH=$(jq --arg ver "$v" -r '.versions[] | select(.name==$ver) | .branch' config.json);
-     scripts/download-content-archive.sh "content/$v" "$BRANCH";
+     REPO=$(jq --arg ver "$v" -r '.versions[] | select(.name==$ver) | .repo_path' config.json);
+     scripts/download-content-archive.sh "content/$v" "$BRANCH" "$REPO";
   done
 else
   git submodule update --init --remote --progress;

--- a/server/config-site.ts
+++ b/server/config-site.ts
@@ -44,6 +44,7 @@ const validator = ajv.compile({
         type: "object",
         properties: {
           name: { type: "string" },
+          repo_path: { type: "string" },
           branch: { type: "string" },
           isDefault: { type: "boolean", nullable: true },
           deprecated: { type: "boolean", nullable: true },


### PR DESCRIPTION
Before #307, external contributors to the docs could preview their contributions on AWS Amplify using `gravitational/teleport` forks by entering their fork URL into the `.gitmodules` configuration. There is no such possibility for the current site, since the `download-content-archive.sh` script hard-codes the GitHub repository from which it downloads archives.

This change adds an optional `repo_path` field to each version metadata object in `config.json`. External contributors can specify a repository path such as "myfork/teleport" for a version, and the `download-content-archive.sh` script fetches a tarball from the fork for that version's content directory.