### PR TITLE
Adjust LandingHero styles for sub headings

### DIFF
--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -139,6 +139,12 @@
     h4 {
       margin-bottom: var(--m-1);
       color: var(--color-black);
+      font-size: var(--fs-header-4);
+
+      @media (--md-scr) {
+        margin-top: var(--m-4);
+        font-size: var(--fs-header-3);
+      }
     }
 
     p > a {


### PR DESCRIPTION
This PR adjusts the style of h2, h3 and h4 headings so that they match the Figma design. According to the design only h2 is expected to be used, but it is applied to h3 and h4 as well in case the wrong heading level is used.