### PR TITLE
node: use node 22 in tests

### DIFF
--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -54,8 +54,9 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 23
+          node-version: 22
           cache: 'yarn'
+
       - name: Install deps
         run: yarn
 
@@ -63,7 +64,8 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .downloads/
-          key: tarball-downloads-${{ hashFiles('.downloads/*.tar.gz') }}
+          key: tarball-downloads-${{ hashFiles('config.json') }}
+          restore-keys: tarball-downloads-
 
       - name: Prepare docs site configuration
         # Replace data fetched from goteleport.com/api/data/navigation with hard coded JSON objects. 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 23
+          node-version: 22
           cache: 'yarn'
       - name: Install deps
         run: yarn && yarn playwright install --with-deps


### PR DESCRIPTION
### Summary

Starting on 15th of September, Amplify will use Node v22 as default per-installed version[^1].

[^1]: https://docs.aws.amazon.com/amplify/latest/userguide/troubleshooting-general.html#update-node-version

While it is possible to download custom node version (like we're currently doing with Node v23), it takes around of 1m (of wasted) build time. It's better to use the default v22 (LTS) version.

This can be merged now, and corresponding PR to update amplify configuration will be merged on September 15th.

**Ride-along**: fixed cache key name for local build.

### Related to

- https://github.com/gravitational/docs-website/issues/255

