### PR TITLE
Landing page components: Replace <a> tags with Docusaurus's built in Link component

### DIFF
--- a/src/components/Pages/Homepage/DocsHeader/DocsHeader.tsx
+++ b/src/components/Pages/Homepage/DocsHeader/DocsHeader.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { InlineSearch } from './InlineSearch';
-import styles from './DocsHeader.module.css';
+import React from "react";
+import { InlineSearch } from "./InlineSearch";
+import styles from "./DocsHeader.module.css";
+import Link from "@docusaurus/Link";
 
 interface DocsHeaderProps {
   title?: string;
@@ -15,7 +16,7 @@ interface DocsHeaderProps {
 function DocsHeader({
   title = "Teleport Documentation",
   hideTitleSection = false,
-  quickActions = []
+  quickActions = [],
 }: DocsHeaderProps) {
   return (
     <section className={styles.docsHeader}>
@@ -33,9 +34,13 @@ function DocsHeader({
           <div className={styles.quickActions}>
             <span className={styles.exampleText}>Example</span>
             {quickActions.map((action, index) => (
-              <a key={index} href={action.href} className={styles.actionButton}>
+              <Link
+                key={index}
+                to={action.href}
+                className={styles.actionButton}
+              >
                 {action.label}
-              </a>
+              </Link>
             ))}
           </div>
         )}

--- a/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import styles from "./GetStarted.module.css";
 
 interface GetStartedStep {
@@ -37,10 +38,10 @@ const GetStarted: React.FC<GetStartedProps> = ({
         <div className={styles.grid}>
           <div className={styles.steps}>
             {steps.map((step, i) => (
-              <a key={i} href={step.href} className={styles.step}>
+              <Link key={i} to={step.href} className={styles.step}>
                 <h3 className={styles.stepTitle}>{step.title}</h3>
                 <p className={styles.stepDescription}>{step.description}</p>
-              </a>
+              </Link>
             ))}
           </div>
           <div className={styles.video}>
@@ -54,13 +55,13 @@ const GetStarted: React.FC<GetStartedProps> = ({
           </div>
           <div className={styles.links}>
             {links.map((link, i) => (
-              <a href={link.href} key={i} className={styles.link}>
+              <Link to={link.href} key={i} className={styles.link}>
                 <div className={styles.linkContent}>
                   <h3 className={styles.linkTitle}>{link.title}</h3>
                   <p className={styles.linkDescription}>{link.description}</p>
                   <link.iconComponent className={styles.linkIcon} />
                 </div>
-              </a>
+              </Link>
             ))}
           </div>
         </div>

--- a/src/components/Pages/Homepage/Integrations/Integrations.tsx
+++ b/src/components/Pages/Homepage/Integrations/Integrations.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "./Integrations.module.css";
 import cn from "classnames";
 import ArrowRightSvg from "@site/src/components/Icon/teleport-svg/arrow-circle-right.svg";
+import Link from "@docusaurus/Link";
 
 interface Integration {
   title: string;
@@ -65,8 +66,8 @@ const IntegrationCard: React.FC<Integration> = ({
   );
 
   return href ? (
-    <a
-      href={href}
+    <Link
+      to={href}
       className={cn(styles.integrationItem, {
         [styles.defaultIcon]: !iconColor,
         [styles.rowLayout]: layout === "row",
@@ -78,7 +79,7 @@ const IntegrationCard: React.FC<Integration> = ({
       }
     >
       {cardContent}
-    </a>
+    </Link>
   ) : (
     <div
       className={cn(styles.integrationItem, {
@@ -123,9 +124,9 @@ const Integrations: React.FC<IntegrationsProps> = ({
             )}
           </div>
           {mainLink && (
-            <a href={mainLink.href} className={styles.mainLink}>
+            <Link to={mainLink.href} className={styles.mainLink}>
               {mainLink.title}
-            </a>
+            </Link>
           )}
         </div>
         <div
@@ -150,9 +151,9 @@ const Integrations: React.FC<IntegrationsProps> = ({
             <ul className={styles.additionalLinksList}>
               {additionalLinks?.links?.map((link, i) => (
                 <li key={i}>
-                  <a href={link.href}>
-                    <ArrowRightSvg /> {link.title}
-                  </a>
+                  <Link to={link.href}>
+                    <LinkrrowRightSvg /> {link.title}
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/src/components/Pages/Homepage/Products/Products.tsx
+++ b/src/components/Pages/Homepage/Products/Products.tsx
@@ -85,7 +85,7 @@ const Products: React.FC<ProductsProps> = ({
                   key={index}
                   title={feature.title}
                   description={feature.description}
-                  to={feature.href}
+                  href={feature.href}
                 />
               ))}
             </div>

--- a/src/components/Pages/Homepage/Products/Products.tsx
+++ b/src/components/Pages/Homepage/Products/Products.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "./Products.module.css";
+import Link from "@docusaurus/Link";
 
 interface ProductFeature {
   title: string;
@@ -35,9 +36,9 @@ const ProductCard: React.FC<ProductFeature> = ({
   );
 
   return href ? (
-    <a href={href} className={styles.featureItem}>
+    <Link to={href} className={styles.featureItem}>
       {cardContent}
-    </a>
+    </Link>
   ) : (
     <div className={styles.featureItem}>{cardContent}</div>
   );
@@ -66,7 +67,7 @@ const Products: React.FC<ProductsProps> = ({
                 <div className={styles.categoryHeader}>
                   <h3 className={styles.categoryTitle}>
                     {category.href ? (
-                      <a href={category.href}>{category.title}</a>
+                      <Link to={category.href}>{category.title}</Link>
                     ) : (
                       category.title
                     )}
@@ -84,7 +85,7 @@ const Products: React.FC<ProductsProps> = ({
                   key={index}
                   title={feature.title}
                   description={feature.description}
-                  href={feature.href}
+                  to={feature.href}
                 />
               ))}
             </div>

--- a/src/components/Pages/Homepage/VersionHighlights/VersionHighlights.tsx
+++ b/src/components/Pages/Homepage/VersionHighlights/VersionHighlights.tsx
@@ -3,6 +3,7 @@ import styles from "./VersionHighlights.module.css";
 import cn from "classnames";
 import FIRST_WHATS_NEW_IMAGE from "../../../../../static/server-mcp-white-bg.png";
 import SECOND_WHATS_NEW_IMAGE from "../../../../../static/database-mcp-white-bg.png";
+import Link from "@docusaurus/Link";
 
 interface VersionHighlight {
   title: string;
@@ -45,16 +46,16 @@ const VersionHighlights: React.FC<VersionHighlightsProps> = ({
           <h2 className={styles.title}>{title}</h2>
           <div className={styles.links}>
             {mainLinks.map((link, index) => (
-              <a key={index} href={link.href} className={styles.link}>
+              <Link key={index} to={link.href} className={styles.link}>
                 {link.title}
-              </a>
+              </Link>
             ))}
           </div>
         </div>
         <ul className={styles.highlightsList}>
           {highlights.map((highlight, index) => (
             <li key={index}>
-              <a href={highlight.href} className={styles.highlightItem}>
+              <Link to={highlight.href} className={styles.highlightItem}>
                 <div className={styles.highlightImage}>
                 <img
                   src={index === 0 ? FIRST_WHATS_NEW_IMAGE : SECOND_WHATS_NEW_IMAGE}
@@ -72,7 +73,7 @@ const VersionHighlights: React.FC<VersionHighlightsProps> = ({
                   </p>
                   <p className={styles.highlightLink}>Read more</p>
                 </div>
-              </a>
+              </Link>
             </li>
           ))}
         </ul>

--- a/src/components/Pages/Landing/LandingHero/LandingHero.tsx
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import styles from "./LandingHero.module.css";
 
 interface GetStartedLink {
@@ -62,13 +63,13 @@ const LandingHero: React.FC<LandingHeroProps> = ({
         {links.length > 0 && (
           <div className={styles.links}>
             {links.map((link, i) => (
-              <a href={link.href} key={i} className={styles.link}>
+              <Link to={link.href} key={i} className={styles.link}>
                 <div className={styles.linkContent}>
                   <h3 className={styles.linkTitle}>{link.title}</h3>
                   <p className={styles.linkDescription}>{link.description}</p>
                   <link.icon className={styles.linkIcon} />
                 </div>
-              </a>
+              </Link>
             ))}
           </div>
         )}


### PR DESCRIPTION
This PR replaces the use of `a` tags in favor of Docusaurus's built-in `Link` component in the following page components:

- DocsHeader
- GetStarted
- Integrations
- Products
- VersionHighlights
- LandingHero

 Using the `Link` component helps to prevent the appearance of broken links.