### PR TITLE
Add a remark linter to require intro paragraphs

### DIFF
--- a/server/lint-page-structure.test.ts
+++ b/server/lint-page-structure.test.ts
@@ -229,4 +229,78 @@ Step 3 instructions
       expect(getReasons(tc.input)).toEqual(tc.expected);
     });
   });
+
+  describe("linting the presence of an intro paragraph", () => {
+    interface testCase {
+      description: string;
+      input: string;
+      expected: Array<string>;
+    }
+
+    const testCases: Array<testCase> = [
+      {
+        description: `missing intro paragraph`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Concepts
+
+Here's some conceptual information.
+`,
+        expected: [
+          "This guide is missing at least one introductory paragraph before the first H2. Use introductory paragraphs to explain the purpose and scope of this guide. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.",
+        ],
+      },
+      {
+        description: `one intro paragraph`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an intro paragraph.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Concepts
+
+Here's some conceptual information.
+`,
+        expected: [],
+      },
+      {
+        description: `multiple intro paragraphs`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an intro paragraph.
+
+This is another intro paragraph.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Concepts
+
+Here's some conceptual information.
+`,
+        expected: [],
+      },
+    ];
+
+    test.each(testCases)("$description", (tc) => {
+      expect(getReasons(tc.input)).toEqual(tc.expected);
+    });
+  });
 });

--- a/server/lint-page-structure.ts
+++ b/server/lint-page-structure.ts
@@ -1,8 +1,8 @@
 import { lintRule } from "unified-lint-rule";
 import { visit } from "unist-util-visit";
-import type { Heading, Text } from "mdast";
+import type { Heading, Paragraph, Text } from "mdast";
 import type { EsmNode, MdxAnyElement, MdxastNode } from "./types-unist";
-import type { Node, Position } from "unist";
+import type { Node, Parent, Position } from "unist";
 
 const mdxNodeTypes = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
 
@@ -12,38 +12,78 @@ interface stepNumber {
   position: Position;
 }
 
+interface h2WithIndex {
+  node: Text;
+  rootIndex: number; // Index of this child within the root node
+}
+
+interface paragraphWithIndex {
+  node: Paragraph;
+  rootIndex: number; // Index of this child within root
+}
+
 const stepNumberPattern = `^Step ([0-9]+)/([0-9]+)`;
 const messageSuffix = `Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.`;
 
 export const remarkLintPageStructure = lintRule(
   "remark-lint:page-structure",
   (root: Node, vfile) => {
-    const h2s: Array<Text> = [];
-    visit(root, undefined, (node: Node) => {
+    const h2s: Array<h2WithIndex> = [];
+    const paras: Array<paragraphWithIndex> = [];
+
+    // Collect paragraphs and headings from first-level children of root.
+    (root as Parent).children.forEach((node, idx) => {
       const hed = node as Heading;
       if (hed.type == "heading" && hed.depth == 2) {
         // A Heading as parsed by remark-mdx only has a single child, the
         // heading text.
-        h2s.push(hed.children[0] as Text);
+        h2s.push({
+          node: hed.children[0] as Text,
+          rootIndex: idx,
+        });
+      }
+
+      const para = node as Paragraph;
+      if (para.type == "paragraph") {
+        paras.push({
+          node: para,
+          rootIndex: idx,
+        });
       }
     });
 
-    const hasStep = h2s.some((h) => h.value.match(/^Step [0-9]/) !== null);
-    if (hasStep && h2s[0].value !== "How it works") {
+    // See if there is a paragraph that comes before the first H2 in root's
+    // children. We compare indices instead of line numbers because
+    // remark-includes preserves the line numbers of any partials it includes.
+    if (
+      h2s.length > 0 &&
+      !paras.some((para) => {
+        return para.rootIndex < h2s[0].rootIndex;
+      })
+    ) {
+      vfile.message(
+        "This guide is missing at least one introductory paragraph before the first H2. Use introductory paragraphs to explain the purpose and scope of this guide. " +
+          messageSuffix,
+        h2s[0].node.position,
+      );
+    }
+
+    const hasStep = h2s.some((h) => h.node.value.match(/^Step [0-9]/) !== null);
+    if (hasStep && h2s[0].node.value !== "How it works") {
       vfile.message(
         "In a how-to guide, the first H2-level section must be called `## How it works`. Use this section to include 1-3 paragraphs that describe the high-level architecture of the setup shown in the guide. " +
           messageSuffix,
-        h2s[0].position,
+        h2s[0].node.position,
       );
     }
     const stepNumbers: Array<stepNumber> = [];
     h2s.forEach((heading) => {
-      const parts = heading.value.match(stepNumberPattern);
+      const parts = heading.node.value.match(stepNumberPattern);
       if (parts !== null) {
         stepNumbers.push({
           numerator: parseInt(parts[1]),
           denominator: parseInt(parts[2]),
-          position: heading.position,
+          position: heading.node.position,
         });
       }
     });


### PR DESCRIPTION
Introductory paragraphs are critical to laying out the scope of a docs page and helping a user determine if they should keep reading. However, docs pages sometimes do not include introductory paragraphs. This change adds a remark linter to require introductory paragraphs before the first top-level heading of a docs page.

Note that while `gravitational/teleport` currently includes a Vale linter for first paragraphs, it is not possible for authors to ignore it using comments because it has the `raw` scope. The linter added by this change supports ignoring via comments. We can also fine-tune the behavior more precisely since it acts on a Markdown AST, rather than text.