### PR TITLE
Disable the persistent Docusaurus cache

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,7 +43,19 @@ const config: Config = {
     },
     // This speeds up build by a lot and should resolve memory issues during build
     // https://docusaurus.io/blog/releases/3.6
-    experimental_faster: true,
+    experimental_faster: {
+      swcJsLoader: true,
+      swcJsMinimizer: true,
+      lightningCssMinimizer: true,
+      rspackBundler: true,
+      // Using the persistent cache causes unexpected issues with retrieving
+      // stale data in CI/CD since it is stored in `node_modules`, which is
+      // often cached. For local development, the cache is unnecessary since
+      // the user changes docs files anyway.
+      rspackPersistentCache: false,
+      mdxCrossCompilerCache: true,
+      ssgWorkerThreads: true,
+    },
   },
   customFields: {
     inkeepConfig: {


### PR DESCRIPTION
Closes gravitational/teleport#59099

The `Lint (Docs)` GitHub Actions job caches the `node_modules` directory to save time installing dependencies when testing the docs build. However, `node_modules` also includes caches managed by Docuscaurus. As a result, builds that retrieve `node_modules` content from the cache can inadvertently pull build artifacts from other `Lint (Docs)` runs.

This change disables persistent Docusaurus cacheing. An alternative would be to enable it for local development, but there is little reason to cache Docusaurus builds when making local changes to the docs.