### PR TITLE
Add a remark linter for improper `Var` use

### DIFF
--- a/server/lint-page-structure.test.ts
+++ b/server/lint-page-structure.test.ts
@@ -229,4 +229,173 @@ Step 3 instructions
       expect(getReasons(tc.input)).toEqual(tc.expected);
     });
   });
+
+  describe("linting improper Var component use", () => {
+    interface testCase {
+      description: string;
+      input: string;
+      expected: Array<string>;
+    }
+
+    const testCases: Array<testCase> = [
+      {
+        description: `single instance of a Var in a code block`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+\`\`\`code
+<Var name="myvar" />
+\`\`\`
+
+`,
+        expected: [
+          'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+        ],
+      },
+      {
+        description: `var in code block with single quotes`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction.
+
+\`\`\`code
+<Var name='myvar' />
+\`\`\`
+
+`,
+        expected: [
+          'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+        ],
+      },
+      {
+        description: `single instance of a Var in paragraph`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+`,
+        expected: [
+          'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+        ],
+      },
+      {
+        description: `valid case`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+\`\`\`code
+<Var name="myvar" />
+\`\`\`
+
+`,
+        expected: [],
+      },
+      {
+        description: `valid case with inline code`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including \`<Var name="myvar" />\`.
+
+\`\`\`code
+<Var name="myvar" />
+\`\`\`
+
+`,
+        expected: [],
+      },
+      {
+        description: `multiple violations`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+\`\`\`code
+<Var name="othervar" />
+\`\`\`
+
+`,
+        expected: [
+          'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+          'There is only a single instance of the Var named "othervar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+        ],
+      },
+      // The apostrophe can trip up regular expression matching
+      {
+        description: `valid case with apostrophe`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar's" />.
+
+\`\`\`code
+<Var name= "myvar's" />
+\`\`\`
+
+`,
+        expected: [],
+      },
+      {
+        description: `valid case with slash`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="arn:aws:iam::(=aws.aws_account_id=):role/teleport-docdb-user" />.
+
+\`\`\`code
+<Var name= "arn:aws:iam::(=aws.aws_account_id=):role/teleport-docdb-user" />
+\`\`\`
+
+`,
+        expected: [],
+      },
+      {
+        description: `valid case with list item`,
+        input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+Here is a list:
+- Item one
+- <Var name="Permission IDs"/>
+
+\`\`\`bash
+cat > variables.auto.tfvars << EOF
+graph_permission_ids    = [<Var name="Permission IDs"/>]
+EOF
+\`\`\`
+
+`,
+        expected: [],
+      },
+    ];
+
+    test.each(testCases)("$description", (tc) => {
+      expect(getReasons(tc.input)).toEqual(tc.expected);
+    });
+  });
 });

--- a/server/lint-page-structure.ts
+++ b/server/lint-page-structure.ts
@@ -1,10 +1,8 @@
 import { lintRule } from "unified-lint-rule";
 import { visit } from "unist-util-visit";
-import type { Heading, Text } from "mdast";
+import type { Heading, Text, Code } from "mdast";
 import type { EsmNode, MdxAnyElement, MdxastNode } from "./types-unist";
 import type { Node, Position } from "unist";
-
-const mdxNodeTypes = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
 
 interface stepNumber {
   numerator: number;
@@ -14,18 +12,86 @@ interface stepNumber {
 
 const stepNumberPattern = `^Step ([0-9]+)/([0-9]+)`;
 const messageSuffix = `Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.`;
+const varPattern = /<Var[^>]+\/?>/g;
+const varNameQuotePattern = /name\s*=\s*(["'])/;
 
 export const remarkLintPageStructure = lintRule(
   "remark-lint:page-structure",
   (root: Node, vfile) => {
+    // Declare data structures for collecting page structure elements when we
+    // traverse the tree. After traversal, we'll explore these data structures
+    // to identify issues.
     const h2s: Array<Text> = [];
+    const varNames = new Map();
+    // The first position of each Var. We only need one since we only use this
+    // for single-instance Vars.
+    const varPositions = new Map();
+
     visit(root, undefined, (node: Node) => {
+      // Collect the names of Vars that are outside of code blocks.
+      const el = node as MdxAnyElement;
+      if (
+        (node.type == "mdxJsxTextElement" ||
+          node.type == "mdxJsxFlowElement") &&
+        el.name == "Var"
+      ) {
+        el.attributes.forEach((a) => {
+          if (a.name == "name") {
+            if (!varNames.has(a.value)) {
+              varNames.set(a.value, 0);
+              varPositions.set(a.value, el.position);
+              return;
+            }
+            varNames.set(a.value, varNames.get(a.value) + 1);
+          }
+        });
+      }
+
       const hed = node as Heading;
       if (hed.type == "heading" && hed.depth == 2) {
         // A Heading as parsed by remark-mdx only has a single child, the
         // heading text.
         h2s.push(hed.children[0] as Text);
       }
+
+      // In a code block, Vars are strings, so find them using regular
+      // expressions.
+      const code = node as Code;
+      if (code.type == "code" || code.type == "inlineCode") {
+        const vars = code.value.matchAll(varPattern);
+        vars.forEach((v) => {
+          // Determine if the "name" param uses single or double quotes.
+          const varQuote = v[0].match(varNameQuotePattern);
+          if (!varQuote) {
+            vfile.message(
+              `Var component found without a valid name`,
+              node.position,
+            );
+          }
+
+          // Extract the name. We know that there is a valid name parameter, so
+          // the array indices are guaranteed to be in range.
+          const namePattern = `name\\s*=\\s*${varQuote[1]}([^${varQuote[1]}]+)${varQuote[1]}`;
+          const varName = v[0].match(new RegExp(namePattern))[1];
+          if (!varNames.has(varName)) {
+            varNames.set(varName, 0);
+            varPositions.set(varName, code.position);
+            return;
+          }
+          varNames.set(varName, varNames.get(varName) + 1);
+        });
+      }
+    });
+
+    varNames.forEach((val, key) => {
+      if (val > 0) {
+        return;
+      }
+      vfile.message(
+        `There is only a single instance of the Var named "${key}" on this page. Add another instance, making it explicit that the user can assign the variable. ` +
+          messageSuffix,
+        varPositions.get(key),
+      );
     });
 
     const hasStep = h2s.some((h) => h.value.match(/^Step [0-9]/) !== null);
@@ -36,6 +102,7 @@ export const remarkLintPageStructure = lintRule(
         h2s[0].position,
       );
     }
+
     const stepNumbers: Array<stepNumber> = [];
     h2s.forEach((heading) => {
       const parts = heading.value.match(stepNumberPattern);


### PR DESCRIPTION
See #204

We currently use a Vale linter to catch improper use of the `Var` component, i.e., pages in which there is a single instance of a `Var` with a particular name. This linter catches `Var`s that are:
- Difficult to find and use, or potentially unnecessary, since there are no instructions to assign the variable, and no repeated values to assign simultaneously with a `Var` in the docs page.
- Mistakenly inconsistent, with names that the author intended to be identical but actually differ.

This change adds a `remark` linter to achive this. The `remark` linter has several advantages over the current Vale linter, including:
- It shows the name of the `Var` that violated the linter, making it much easier to use.
- It can be ignored with comments. The Vale linter cannot be ignored with comments since it uses the `raw` scope, and only Vale linters without the `raw` scope can be ignored with comments.
- We can use unit tests to verify that it works and catch edge cases.