### PR TITLE
docs: changing Resources component title to sentence case

### DIFF
--- a/src/components/Pages/Homepage/Resources/Resources.tsx
+++ b/src/components/Pages/Homepage/Resources/Resources.tsx
@@ -41,7 +41,7 @@ const ResourceCard: React.FC<Resource> = ({
 
 const Resources: React.FC<ResourcesProps> = ({
   className = "",
-  title = "Enroll Resources",
+  title = "Enroll resources",
   resources,
 }) => {
   return (


### PR DESCRIPTION
The headings on docs pages should be sentence case. This PR updates the Resources component title to be sentence case.