### PR TITLE
Reconfigure remarkVersionAlias in the docs config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -243,7 +243,7 @@ const config: Config = {
         versions: getDocusaurusConfigVersionOptions(),
         // Our custom plugins need to be before default plugins
         beforeDefaultRemarkPlugins: [
-          [remarkVersionAlias, latestVersion],
+          [remarkVersionAlias, getCurrentVersion()],
           [
             remarkIncludes,
             {

--- a/server/remark-version-alias.ts
+++ b/server/remark-version-alias.ts
@@ -7,7 +7,7 @@ import { visit, CONTINUE, SKIP } from "unist-util-visit";
 
 const versionedDocsPattern = `versioned_docs/version-([0-9]+\\.x)/`;
 
-export default function remarkVersionAlias(latestVersion: string): Transformer {
+export default function remarkVersionAlias(currentVersion: string): Transformer {
   return (root: Root, vfile: VFile) => {
     visit(root, (node: Node) => {
       if (node.type != "mdxjsEsm") {
@@ -21,7 +21,7 @@ export default function remarkVersionAlias(latestVersion: string): Transformer {
         return CONTINUE;
       }
 
-      let version: string = latestVersion;
+      let version: string = currentVersion;
       let newVal: Array<string> = [];
       const versionedPathParts = vfile.path.match(versionedDocsPattern);
       if (versionedPathParts) {


### PR DESCRIPTION
The current configuration is based on a misleading parameter name in `remark-version-alias`, in which the parameter, `latestVersion`, indicates the version of the docs in the `docs` directory. The current `docusaurus.config.ts` populates that with the result of `getLatestVersion`.

However, in Docusaurus parlance, the "latest" version is the default version of the docs site, while the "current" version is the edge version.

This change renames the misleading parameter in `remark-verison-alias` and sets it to the expected value in `docusaurus.config.ts`.