### PR TITLE
docs: fix FeatureMatrixBanner component horizontal padding

### DIFF
--- a/src/components/Pages/GetStarted/FeatureMatrixBanner/FeatureMatrixBanner.module.css
+++ b/src/components/Pages/GetStarted/FeatureMatrixBanner/FeatureMatrixBanner.module.css
@@ -2,7 +2,7 @@
   background-color: var(--color-background-depth-2);
   border: 2px solid var(--color-tonal-neutral-0);
   border-radius: 12px;
-  padding: var(--m-3) var(--m-2);
+  padding: var(--m-3) var(--m-4);
   margin: var(--m-5) 0;
 }
 


### PR DESCRIPTION
This commit fixes the horizontal padding on the `FeatureMatrixBanner` component to match the padding of the `TeleportEditionCard` tiles above it on the main get started page. Both now at 32px.

## Before:
<img width="388" height="455" alt="image" src="https://github.com/user-attachments/assets/91d9f61d-75b9-41b5-bfc4-05d77d907f61" />

## After: 
<img width="532" height="459" alt="image" src="https://github.com/user-attachments/assets/9fcfa3ef-0e42-40cb-9178-039013eafcc5" />
