### PR TITLE
Configure Dependabot groups and limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
+      aws-actions:
+        patterns:
+          - "aws-actions/*"
+      docker-actions:
+        patterns:
+          - "docker/*"
     reviewers:
       - emargetis
       - taraspos
@@ -24,7 +35,7 @@ updates:
       - "nodejs"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     groups:
       docusaurus:
         patterns:


### PR DESCRIPTION
New version of docusaurus got released, however dependabot won't open PR for it, because it reached the limit of PRs, because we have bunch of major remark upgrades pending. This adds better PR grouppings and increases open PR limit for NPM.