### PR TITLE
Applications page

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "18.x",
-      "branch": "aatuvai/mcp-servers-page",
+      "branch": "aatuvai/applications-page",
       "repo_path": "aatuvai/teleport",
       "isDefault": true
     },

--- a/src/components/Pages/Homepage/Resources/Resources.module.css
+++ b/src/components/Pages/Homepage/Resources/Resources.module.css
@@ -11,6 +11,13 @@
       padding-bottom: var(--m-8);
     }
   }
+
+  &.narrowBottomPadding {
+    padding-bottom: var(--m-2);
+    @media (--md-scr) {
+      padding-bottom: var(--m-2);
+    }
+  }
 }
 
 .resourcesContainer {
@@ -46,16 +53,22 @@
   grid-template-columns: 1fr;
   gap: var(--m-2);
 
-  @media (min-width: 577px) {
-    grid-template-columns: repeat(2, 1fr);
+  @media (--md-scr) {
+    grid-template-columns: repeat(
+      min(2, var(--desktop-column-count)),
+      minmax(0, 1fr)
+    );
   }
 
-  @media (--lg-scr) {
-    grid-template-columns: repeat(3, 1fr);
+  @media (--md-scr) {
+    grid-template-columns: repeat(
+      min(3, var(--desktop-column-count)),
+      minmax(0, 1fr)
+    );
   }
 
   @media (--xl-scr) {
-    grid-template-columns: repeat(var(--desktop-column-count), 1fr);
+    grid-template-columns: repeat(var(--desktop-column-count), minmax(0, 1fr));
   }
 }
 
@@ -111,6 +124,32 @@ a.resourceItem {
   @media (max-width: 576px) {
     font-size: 1rem;
   }
+
+  a {
+    color: var(--color-black);
+    position: relative;
+    display: inline-flex;
+    text-decoration: inherit;
+    align-items: center;
+    &::after {
+      content: "";
+      position: absolute;
+      background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2218%22%20height%3D%2216%22%20viewBox%3D%220%200%2018%2016%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M11.0303%201.19233C10.7374%200.899433%2010.2626%200.899433%209.96967%201.19233C9.67678%201.48522%209.67678%201.96009%209.96967%202.25299L15.4393%207.72266H0.75C0.335786%207.72266%200%208.05844%200%208.47266C0%208.88687%200.335786%209.22266%200.75%209.22266H15.4393L9.96967%2014.6923C9.67678%2014.9852%209.67678%2015.4601%209.96967%2015.753C10.2626%2016.0459%2010.7374%2016.0459%2011.0303%2015.753L17.7803%209.00299C17.9268%208.85654%2018%208.6646%2018%208.47266C18%208.37096%2017.9798%208.274%2017.9431%208.18557C17.9065%208.09711%2017.8522%208.01423%2017.7803%207.94233L11.0303%201.19233Z%22%20fill%3D%22%23512FC9%22%2F%3E%3C%2Fsvg%3E");
+      width: 18px;
+      height: 15px;
+      right: -29px;
+      top: 50%;
+      opacity: 0;
+      transform: translateY(-50%);
+      transition: opacity 0.15s ease-in-out;
+    }
+    &:hover {
+      color: var(--color-dark-purple);
+      &::after {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 .resourceDescription {
@@ -128,5 +167,55 @@ a.resourceItem {
       font-size: var(--fs-text-xl);
       line-height: 1.66667;
     }
+  }
+}
+
+.tags {
+  display: flex;
+  gap: var(--m-1);
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0 !important;
+  align-items: center;
+  margin-top: var(--m-2);
+}
+
+.tagIcon {
+  width: var(--m-3);
+  height: var(--m-3);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tagArrow {
+  width: var(--m-2);
+  height: var(--m-2);
+}
+
+.tag {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-tonal-neutral-0);
+  border-radius: var(--m-1);
+  padding: var(--m-1) var(--m-2);
+  font-size: var(--fs-text-md);
+  display: flex;
+  align-items: center;
+  gap: var(--m-1);
+  color: var(--color-black);
+  text-decoration: none;
+  font-weight: var(--fw-regular);
+  position: relative;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    color: var(--color-black);
+    text-decoration: none;
+    box-shadow: var(--lp-box-shadow-hover-tag);
+  }
+
+  @media (--md-scr) {
+    font-size: var(--fs-text-lg);
   }
 }

--- a/src/components/Pages/Homepage/Resources/Resources.tsx
+++ b/src/components/Pages/Homepage/Resources/Resources.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import cn from "classnames";
 import styles from "./Resources.module.css";
 import Link from "@docusaurus/Link";
+import { Tag } from "../../Landing/UseCasesList/UseCasesList";
+import Icon from "@site/src/components/Icon";
 
 interface Resource {
   title: string;
@@ -9,6 +11,7 @@ interface Resource {
   iconComponent: any;
   href?: string;
   variant?: "homepage" | "doc";
+  tags?: Tag[];
 }
 
 interface ResourcesProps {
@@ -17,6 +20,7 @@ interface ResourcesProps {
   variant?: "homepage" | "doc";
   desktopColumnsCount?: number;
   resources: Resource[];
+  narrowBottomPadding?: boolean;
 }
 
 const ResourceCard: React.FC<Resource> = ({
@@ -25,6 +29,7 @@ const ResourceCard: React.FC<Resource> = ({
   href,
   iconComponent,
   variant,
+  tags,
 }) => {
   const IconComponent = iconComponent;
   const cardContent = (
@@ -34,7 +39,9 @@ const ResourceCard: React.FC<Resource> = ({
           [styles.docVariant]: variant === "doc",
         })}
       />
-      <h4 className={styles.resourceTitle}>{title}</h4>
+      <h4 className={styles.resourceTitle}>
+        {tags?.length > 0 ? <Link to={href}>{title}</Link> : title}
+      </h4>
       <p
         className={cn(styles.resourceDescription, {
           [styles.docVariant]: variant === "doc",
@@ -42,9 +49,49 @@ const ResourceCard: React.FC<Resource> = ({
       >
         {description}
       </p>
+      {tags?.length > 0 && (
+        <ul className={styles.tags}>
+          {tags.map((tag, tagIndex) => (
+            <li key={tagIndex}>
+              {tag.href ? (
+                // @ts-ignore
+                <Link className={styles.tag} to={tag.href}>
+                  {tag.icon && (
+                    <Icon
+                      name={tag.icon}
+                      size="md"
+                      className={styles.tagIcon}
+                    />
+                  )}
+                  {tag.name}
+                  {tag.arrow && (
+                    // @ts-ignore
+                    <ArrowRightSvg className={styles.tagArrow} />
+                  )}
+                </Link>
+              ) : (
+                <span className={styles.tag}>
+                  {tag.icon && (
+                    <Icon
+                      name={tag.icon}
+                      size="md"
+                      className={styles.tagIcon}
+                    />
+                  )}
+                  {tag.name}
+                  {tag.arrow && (
+                    // @ts-ignore
+                    <ArrowRightSvg className={styles.tagArrow} />
+                  )}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </>
   );
-  return href ? (
+  return href && (!tags || tags.length === 0) ? (
     // @ts-ignore
     <Link to={href} className={styles.resourceItem}>
       {cardContent}
@@ -60,21 +107,25 @@ const Resources: React.FC<ResourcesProps> = ({
   variant = "homepage",
   desktopColumnsCount = 4,
   resources,
+  narrowBottomPadding = false,
 }) => {
   return (
     <section
       className={cn(styles.resources, className, {
         [styles.docVariant]: variant === "doc",
+        [styles.narrowBottomPadding]: narrowBottomPadding,
       })}
     >
       <div className={styles.resourcesContainer}>
-        <h2
-          className={cn(styles.resourcesTitle, {
-            [styles.docVariant]: variant === "doc",
-          })}
-        >
-          {title}
-        </h2>
+        {title && (
+          <h2
+            className={cn(styles.resourcesTitle, {
+              [styles.docVariant]: variant === "doc",
+            })}
+          >
+            {title}
+          </h2>
+        )}
         <div
           className={styles.resourcesGrid}
           style={
@@ -91,6 +142,7 @@ const Resources: React.FC<ResourcesProps> = ({
               href={resource.href}
               variant={variant}
               iconComponent={resource.iconComponent}
+              tags={resource.tags}
             />
           ))}
         </div>

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.module.css
@@ -5,10 +5,19 @@
   @media (--md-scr) {
     padding-bottom: var(--m-8);
   }
+
+  &.narrowBottomPadding {
+    padding-bottom: var(--m-2);
+    @media (--md-scr) {
+      padding-bottom: var(--m-2);
+    }
+  }
 }
 
 .header {
-  margin-bottom: var(--m-3);
+  &.hasTitle {
+    margin-bottom: var(--m-3);
+  }
 }
 
 .title {
@@ -63,7 +72,10 @@
   grid-template-columns: minmax(0, 1fr);
 
   @media (--md-scr) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(
+      min(2, var(--desktop-column-count)),
+      minmax(0, 1fr)
+    );
   }
 
   @media (--lg-scr) {
@@ -79,7 +91,7 @@
   display: block;
   padding: var(--m-2) var(--m-3);
   border-radius: 12px;
-  border: 1px solid var(--color-tonal-neutral-1);
+  border: 1px solid var(--color-tonal-neutral-0);
   transition: all 0.2s ease-in-out;
   text-decoration: none;
   height: 100%;

--- a/src/components/Pages/Landing/UseCasesList/UseCasesList.tsx
+++ b/src/components/Pages/Landing/UseCasesList/UseCasesList.tsx
@@ -5,7 +5,7 @@ import Icon, { IconName } from "@site/src/components/Icon";
 import Link from "@docusaurus/Link";
 import ArrowRightSvg from "@site/src/components/Icon/teleport-svg/arrow-right.svg";
 
-interface Tag {
+export interface Tag {
   name: string;
   icon: IconName;
   href: string;
@@ -24,6 +24,7 @@ interface UseCasesListProps {
     href?: string;
     tags?: Tag[];
   }>;
+  narrowBottomPadding?: boolean;
 }
 
 const UseCasesList: React.FC<UseCasesListProps> = ({
@@ -33,18 +34,25 @@ const UseCasesList: React.FC<UseCasesListProps> = ({
   desktopColumnsCount = 3,
   useCases = [],
   variant = "landing",
+  narrowBottomPadding = false,
 }) => {
   return (
-    <section className={cn(styles.useCasesList, className)}>
+    <section
+      className={cn(styles.useCasesList, className, {
+        [styles.narrowBottomPadding]: narrowBottomPadding,
+      })}
+    >
       <div className={styles.container}>
-        <div className={styles.header}>
-          <h2
-            className={cn(styles.title, {
-              [styles.docVariant]: variant === "doc",
-            })}
-          >
-            {title}
-          </h2>
+        <div className={cn(styles.header, { [styles.hasTitle]: !!title })}>
+          {title && (
+            <h2
+              className={cn(styles.title, {
+                [styles.docVariant]: variant === "doc",
+              })}
+            >
+              {title}
+            </h2>
+          )}
           {description && <p className={styles.description}>{description}</p>}
         </div>
         <ul


### PR DESCRIPTION
This PR adds several changes in order to implement [the new design](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=4302-45095) for the Applications page.

Changes:
- Edit the UseCasesList component by adding a new boolean property called narrowBottomPadding. It is used to stack the UseCasesList components on top of another and thus allow a varying column count.
- Edit the Resources component by adding the option to add tags to the items.  Also add the same narrowBottomPadding property option as in UseCasesList.