### PR TITLE
docs: adding optional tooltip to Tiles in TileGrid

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "18.x",
-      "branch": "branch/v18",
+      "branch": "travis.rodgers/tooltip-test",
       "isDefault": true
     },
     {

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -6,15 +6,15 @@ interface TileProps {
   icon: React.ReactNode;
   to: string;
   name: string;
+  tooltip?: string;
 }
 
-export default function Tile({ icon, to, name }: TileProps) {
+export default function Tile({ icon, to, name, tooltip }: TileProps) {
+  const ariaLabel = tooltip ? `${name}: ${tooltip}` : name;
   return (
-    <>
-      <a href={to} className={styles.tile}>
-        {icon}
-        {name}
-      </a>
-    </>
+    <a href={to} className={styles.tile} title={tooltip} aria-label={ariaLabel}>
+      {icon}
+      {name}
+    </a>
   );
 }

--- a/src/components/TileGrid/TileGrid.tsx
+++ b/src/components/TileGrid/TileGrid.tsx
@@ -7,6 +7,7 @@ interface TileGridProps {
     icon: React.ReactNode;
     to: string;
     name: string;
+    tooltip?: string;
   }[];
 }
 
@@ -14,7 +15,7 @@ export default function TileGrid({ tiles }: TileGridProps) {
   return (
     <div className={styles.gridContainer}>
       {tiles.map((tile, index) => (
-        <Tile key={index} icon={tile.icon} to={tile.to} name={tile.name} />
+        <Tile key={index} icon={tile.icon} to={tile.to} name={tile.name} tooltip={tile.tooltip} />
       ))}
     </div>
   );


### PR DESCRIPTION
This PR adds the optional ability to add an HTML native tooltip to the Tiles in the TileGrid for further descriptions (just adding the title attribute). 
An ariaLabel is also added for accessibility and unnecessary fragment removed.
Context behind this PR found at https://github.com/gravitational/teleport/pull/59775#discussion_r2403323457

Preview tooltips on page https://travis-rodgers-add-optional-tooltip-to-tiles.d2mrezcly5gcqm.amplifyapp.com/docs/machine-workload-identity/mwi-ci-cd/