### PR TITLE
docs: make embedded video by ID rather than by URL

### DIFF
--- a/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
@@ -15,19 +15,18 @@ interface GetStartedLink {
 
 interface GetStartedProps {
   title: string;
-  youtubeVideoUrl: string;
+  youtubeVideoId: string;
   steps?: GetStartedStep[];
   links?: GetStartedLink[];
 }
 
 const GetStarted: React.FC<GetStartedProps> = ({
   title = "Get Started",
-  youtubeVideoUrl,
+  youtubeVideoId,
   steps = [],
   links = [],
 }) => {
-  const getEmbedYouTubeUrl = (url: string) => {
-    const videoId = url.split("v=")[1];
+  const getEmbedYouTubeUrl = (videoId: string) => {
     return `https://www.youtube.com/embed/${videoId}`;
   };
   return (
@@ -45,7 +44,7 @@ const GetStarted: React.FC<GetStartedProps> = ({
           </div>
           <div className={styles.video}>
             <iframe
-              src={getEmbedYouTubeUrl(youtubeVideoUrl)}
+              src={getEmbedYouTubeUrl(youtubeVideoId)}
               title={title}
               allowFullScreen
               className={styles.videoIframe}

--- a/src/components/Pages/Landing/LandingHero/LandingHero.tsx
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.tsx
@@ -10,7 +10,7 @@ interface GetStartedLink {
 interface LandingHeroProps {
   title: string;
   image?: any;
-  youtubeVideoUrl?: string;
+  youtubeVideoId?: string;
   linksTitle?: string;
   linksColumnCount?: number;
   links?: GetStartedLink[];
@@ -20,14 +20,13 @@ interface LandingHeroProps {
 const LandingHero: React.FC<LandingHeroProps> = ({
   title,
   image,
-  youtubeVideoUrl,
+  youtubeVideoId,
   linksTitle,
   linksColumnCount = 2,
   links = [],
   children,
 }) => {
-  const getEmbedYouTubeUrl = (url: string) => {
-    const videoId = url.split("v=")[1];
+  const getEmbedYouTubeUrl = (videoId: string) => {
     return `https://www.youtube.com/embed/${videoId}`;
   };
 
@@ -40,7 +39,7 @@ const LandingHero: React.FC<LandingHeroProps> = ({
             <div className={styles.description}>{children}</div>
           </div>
           <div className={styles.media}>
-            {image && !youtubeVideoUrl && (
+            {image && !youtubeVideoId && (
               <img
                 className={styles.image}
                 src={image}
@@ -49,12 +48,12 @@ const LandingHero: React.FC<LandingHeroProps> = ({
                 height={225}
               />
             )}
-            {youtubeVideoUrl && (
+            {youtubeVideoId && (
               <iframe
                 className={styles.video}
                 width={400}
                 height={225}
-                src={getEmbedYouTubeUrl(youtubeVideoUrl)}
+                src={getEmbedYouTubeUrl(youtubeVideoId)}
                 title={title}
                 frameBorder="0"
                 allowFullScreen


### PR DESCRIPTION
The embedded YouTube video feature is currently implemented in a way that requires us to pass the full url like https://www.youtube.com/watch?v=JJftMAwMld8. 

Given that there are at least 3 different youtube URL formats, 
https://youtu.be/JJftMAwMld8
https://www.youtube.com/watch?v=JJftMAwMld8
https://youtu.be/JJftMAwMld8?si=CD8rtCN3CbYjs13F

...we don't want any obscurity on which to use. This PR updates so we only need to pass the video ID as an argument and not the full URL. 

Preview - https://travis-rodgers-make-embedded-video-by-id.d2mrezcly5gcqm.amplifyapp.com/docs/identity-security/