### PR TITLE
docs: update TeleportEditionCard to use Link component

### DIFF
--- a/src/components/Pages/GetStarted/TeleportEditionCard/TeleportEditionCard.tsx
+++ b/src/components/Pages/GetStarted/TeleportEditionCard/TeleportEditionCard.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import Icon, { type IconName } from "@site/src/components/Icon";
 import styles from "./TeleportEditionCard.module.css";
 
@@ -21,7 +22,12 @@ const TeleportEditionCard: React.FC<TeleportEditionCardProps> = ({
   children,
 }) => {
   return (
-    <a href={href} className={`${styles.card} ${className}`} id={id}>
+    // @ts-ignore
+    <Link
+      to={href}
+      className={`${styles.card} ${className}`}
+      id={id}
+    >
       <div className={styles.header}>
         <div className={styles.iconWrapper}>
           <Icon name={iconName} size="md" />
@@ -38,7 +44,7 @@ const TeleportEditionCard: React.FC<TeleportEditionCardProps> = ({
       <div className={styles.content}>
         {children}
       </div>
-    </a>
+    </Link>
   );
 };
 


### PR DESCRIPTION
This PR updates the TeleportEditionCard to use Docusaurus's Link component instead of the regular html link. 

This provides a number of improvements to include opening external links in a new tab which is needed for  instances of its usage. 