### PR TITLE
Add noindex to non-default docs versions

### DIFF
--- a/server/config-site.ts
+++ b/server/config-site.ts
@@ -116,6 +116,7 @@ export const getDocusaurusConfigVersionOptions = (): Record<
       label: isCurrent ? `${name} (unreleased)` : name,
       // Configure root path for the version. Latest in the root, others in the `ver/XX.x` folder.
       path: isDefault ? "" : `ver/${name}`,
+      noIndex: !isDefault,
     };
 
     // Banner will show message for the current version that it is still WIP.


### PR DESCRIPTION
Edit the Docusaurus site configuration to add a `noindex` meta tag to docs pages that are not on the default version of the docs site.