### PR TITLE
Allow tab item synchronization

### DIFF
--- a/src/theme/Tabs/index.tsx
+++ b/src/theme/Tabs/index.tsx
@@ -15,27 +15,46 @@ export default function TabsWrapper(props: Props): ReactNode {
   //
   // The Tabs component checks TabItems for the value property, so we need to
   // assign it here rather than in TabItem.
-  const newProps = {
-    children: React.Children.toArray(children).map((child, idx) => {
-      if (typeof child.props != "object" || !("label" in child.props)) {
-        return child;
-      }
+  const tabItems = React.Children.toArray(children).map((child, idx) => {
+    if (typeof child.props != "object" || !("label" in child.props)) {
+      return child;
+    }
 
-      // The props object cannot have new properties assigned to it, so we need
-      // to return a new object.
-      return {
-        ...child,
-        props: {
-          ...child.props,
-          value: idx,
-        },
-      };
-    }),
+    const value = child.props.label.toLowerCase().trim().replace(" ", "-");
+
+    // The props object cannot have new properties assigned to it, so we need
+    // to return a new object.
+    return {
+      ...child,
+      props: {
+        ...child.props,
+        value: value,
+      },
+    };
+  });
+
+  // Sort tab items by label so the synchronized tab selection also, ideally,
+  // selects the same tab index.
+  tabItems.sort((a, b) => {
+    if (a.label < b.label) {
+      return -1;
+    } else if (a.label > b.label) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  const newProps = {
+    children: tabItems,
   };
 
+  // Use a fixed groupId to allow synchronization between all Tabs instances in
+  // the docs, as long as they share at least one TabItem with the same value.
+  const tabProps = { ...newProps, groupId: "tabs" };
   return (
     <>
-      <Tabs {...newProps} />
+      <Tabs {...tabProps} />
     </>
   );
 }


### PR DESCRIPTION
In this change, when a reader selects a tab item with a given label, the docs site selects all tab items in the docs with the same label. This makes it easier for a reader to interact with docs pages with a lot of tabs, since they do not need to continually watch for incorrect tab selections and click the correct tab item on each `Tabs` component they encounter.

Docusaurus has built-in tab synchronization. `Tabs` components with the same `groupId` prop render tab items with the same `value` as selected [1]. The wrapped `Tabs` component we include in the docs site source already assigns `Tabs` props automatically. This change adjusts the prop assignment logic to assign every `Tabs` component the same `groupId`. It also assigns every tab item a `value` based on its label. This lets us synchronize every tab selection in the docs, even when the tab items in one `Tabs` include labels that other `Tabs` don't, without requiring any new work on the part of docs authors.

[1]:
https://docusaurus.io/docs/markdown-features/tabs#syncing-tab-choices