### PR TITLE
Revert Node version change

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     ]
   },
   "engines": {
-    "node": ">=22.0"
+    "node": ">=18.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
The change in #437 added v22 as the expected Node version in package.json. However, GHA workflows that install dependencies in `gravitational/teleport` turn out not to use this field to choose the version of Node to install, creating a version mismatch between the GHA runner and the expected version. Since we only need v22 for the linter change that we reverted in #437, restore v18 as the expected Node version.