### PR TITLE
docs: lowercase Get Started heading

### DIFF
--- a/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.tsx
@@ -22,7 +22,7 @@ interface GetStartedProps {
 }
 
 const GetStarted: React.FC<GetStartedProps> = ({
-  title = "Get Started",
+  title = "Get started",
   youtubeVideoId,
   steps = [],
   links = [],


### PR DESCRIPTION
This PR fixes the Get Started component header to be sentence case to be consistent with the style guide