### PR TITLE
Edit trackEvent to accommodate Google Tag Manager

### DIFF
--- a/src/components/Command/Command.stories.tsx
+++ b/src/components/Command/Command.stories.tsx
@@ -2,13 +2,13 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect } from "@storybook/test";
 import { userEvent, within } from "@storybook/test";
 import { replaceClipboardWithCopyBuffer } from "/src/utils/clipboard";
-import { collectGtagCalls } from "/src/utils/analytics";
+import { collectEvents } from "/src/utils/analytics";
 import Command, { CommandLine } from "./Command";
 
 const commandText = "yarn install";
 
 export const SimpleCommand = () => (
-  <Command gtag={collectGtagCalls()}>
+  <Command emitEvent={collectEvents()}>
     <CommandLine data-content="$ ">{commandText}</CommandLine>
   </Command>
 );
@@ -30,8 +30,9 @@ export const CopyButton: Story = {
       await userEvent.hover(canvas.getByText(commandText));
       await userEvent.click(canvas.getByTestId("copy-button"));
       expect(navigator.clipboard.readText()).toEqual(commandText);
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "code",
         scope: "line",
       });

--- a/src/components/Command/Command.tsx
+++ b/src/components/Command/Command.tsx
@@ -27,12 +27,12 @@ export function CommandComment(props: CommandCommentProps) {
 
 export interface CommandProps {
   children: ReactNode;
-  gtag?: (command: string, name: string, params: any) => {};
+  emitEvent?: (name: string, params: any) => {};
 }
 
 const commandKey = "command";
 
-export default function Command({ children, gtag, ...props }: CommandProps) {
+export default function Command({ children, emitEvent, ...props }: CommandProps) {
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const codeRef = useRef<HTMLDivElement>();
   const posProvider = useContext(PositionContext);
@@ -61,7 +61,7 @@ export default function Command({ children, gtag, ...props }: CommandProps) {
         line_index_in_snippet: pos,
         line_count_in_snippet: commandCount,
       },
-      gtag: gtag,
+      emitEvent: emitEvent,
     });
 
     if (!navigator.clipboard) {

--- a/src/components/Snippet/Snippet.stories.tsx
+++ b/src/components/Snippet/Snippet.stories.tsx
@@ -7,12 +7,12 @@ import { default as Snippet } from "./Snippet";
 import Command, { CommandLine, CommandComment } from "../Command/Command";
 import { CodeLine } from "/src/theme/MDXComponents/Code";
 import { replaceClipboardWithCopyBuffer } from "/src/utils/clipboard";
-import { collectGtagCalls } from "/src/utils/analytics";
+import { collectEvents } from "/src/utils/analytics";
 import { PositionProvider } from "/src/components/PositionProvider";
 
 export const SimpleCommand = () => (
-  <Snippet gtag={collectGtagCalls()}>
-    <Command gtag={collectGtagCalls()}>
+  <Snippet emitEvent={collectEvents()}>
+    <Command emitEvent={collectEvents()}>
       <CommandLine data-content="$ ">echo Hello world!</CommandLine>
     </Command>
   </Snippet>
@@ -28,8 +28,8 @@ type Story = StoryObj<typeof Snippet>;
 export const CopyCommandVar: Story = {
   render: () => {
     return (
-      <Snippet gtag={collectGtagCalls()}>
-        <Command gtag={collectGtagCalls()}>
+      <Snippet emitEvent={collectEvents()}>
+        <Command emitEvent={collectEvents()}>
           <CommandLine data-content="$ ">
             curl https://
             <Var name="example.com" isGlobal={false} description="" />
@@ -61,7 +61,7 @@ export const CopyCommandVar: Story = {
 export const CopyCommandVarWithOutput: Story = {
   render: () => {
     return (
-      <Snippet gtag={collectGtagCalls()}>
+      <Snippet emitEvent={collectEvents()}>
         <Command>
           <CommandLine data-content="$ ">
             curl https://
@@ -93,7 +93,7 @@ export const CopyCodeLineVar: Story = {
   render: () => {
     return (
       <PositionProvider>
-        <Snippet gtag={collectGtagCalls()}>
+        <Snippet emitEvent={collectEvents()}>
           <CodeLine>
             curl https://
             <Var name="example.com" isGlobal={false} description="" />
@@ -114,8 +114,9 @@ export const CopyCodeLineVar: Story = {
       expect(navigator.clipboard.readText()).toEqual(
         "curl https://example.com/v1/webapi/saml/acs/azure-saml",
       );
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "code",
         scope: "snippet",
         code_snippet_index_on_page: 0,
@@ -129,8 +130,8 @@ export const CopyCommandLineStats: Story = {
   render: () => {
     return (
       <PositionProvider>
-        <Snippet gtag={collectGtagCalls()}>
-          <Command gtag={collectGtagCalls()}>
+        <Snippet emitEvent={collectEvents()}>
+          <Command emitEvent={collectEvents()}>
             <CommandLine data-content="$ ">
               curl https://
               <Var name="sub4.example.com" isGlobal={false} description="" />
@@ -138,22 +139,22 @@ export const CopyCommandLineStats: Story = {
             </CommandLine>
           </Command>
         </Snippet>
-        <Snippet gtag={collectGtagCalls()}>
-          <Command gtag={collectGtagCalls()}>
+        <Snippet emitEvent={collectEvents()}>
+          <Command emitEvent={collectEvents()}>
             <CommandLine data-content="$ ">
               curl https://
               <Var name="sub1.example.com" isGlobal={false} description="" />
               /v1/webapi/saml/acs/azure-saml
             </CommandLine>
           </Command>
-          <Command gtag={collectGtagCalls()}>
+          <Command emitEvent={collectEvents()}>
             <CommandLine data-content="$ ">
               curl https://
               <Var name="sub2.example.com" isGlobal={false} description="" />
               /v1/webapi/saml/acs/azure-saml
             </CommandLine>
           </Command>
-          <Command gtag={collectGtagCalls()}>
+          <Command emitEvent={collectEvents()}>
             <CommandLine data-content="$ ">
               curl https://
               <Var name="sub3.example.com" isGlobal={false} description="" />
@@ -171,8 +172,9 @@ export const CopyCommandLineStats: Story = {
     await step("Copy the second command", async () => {
       await userEvent.hover(canvas.getByText("sub2.example.com"));
       await userEvent.click(canvas.getAllByTestId("copy-button")[2]);
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "code",
         scope: "line",
         code_snippet_index_on_page: 1,

--- a/src/components/Snippet/Snippet.tsx
+++ b/src/components/Snippet/Snippet.tsx
@@ -3,12 +3,12 @@ import styles from "./Snippet.module.css";
 
 export interface SnippetProps {
   children: React.ReactNode;
-  gtag?: (command: string, name: string, params: any) => {};
+  emitEvent?: (command: string, name: string, params: any) => {};
 }
 
-export default function Snippet({ children, gtag }: SnippetProps) {
+export default function Snippet({ children, emitEvent }: SnippetProps) {
   return (
-    <Pre className={styles.wrapper} gtag={gtag}>
+    <Pre className={styles.wrapper} emitEvent={emitEvent}>
       <div className={styles.scroll}>{children}</div>
     </Pre>
   );

--- a/src/theme/MDXComponents/Pre.stories.tsx
+++ b/src/theme/MDXComponents/Pre.stories.tsx
@@ -6,10 +6,10 @@ import { replaceClipboardWithCopyBuffer } from "/src/utils/clipboard";
 import { Var } from "/src/components/Variables/Var";
 import { VarsProvider } from "/src/components/Variables/context";
 import { PositionProvider } from "/src/components/PositionProvider";
-import { collectGtagCalls } from "/src/utils/analytics";
+import { collectEvents } from "/src/utils/analytics";
 
 export const SimplePre = () => (
-  <Pre gtag={collectGtagCalls()}>
+  <Pre emitEvent={collectEvents()}>
     <code className="hljs language-yaml">
       <span className="hljs-attr">key1:</span>{" "}
       <span className="hljs-string">value</span>
@@ -65,7 +65,7 @@ export const CopyVarInPre: Story = {
   render: () => {
     return (
       <VarsProvider>
-        <Pre gtag={collectGtagCalls()}>
+        <Pre emitEvent={collectEvents()}>
           <code className="hljs language-yaml">
             <span className="hljs-attr">key1:</span>{" "}
             <span className="hljs-string">value</span>
@@ -106,8 +106,9 @@ key3:
  - value2
  - value3`,
       );
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "yaml",
         // Snippet-level copy button, rather than the copy button for a code
         // line
@@ -122,12 +123,12 @@ export const CopyVarWithThreePres: Story = {
     return (
       <PositionProvider>
         <VarsProvider>
-          <Pre gtag={collectGtagCalls()}>
+          <Pre emitEvent={collectEvents()}>
             <code className="hljs language-text">
               <span className="hljs-string">Some text</span>
             </code>
           </Pre>
-          <Pre gtag={collectGtagCalls()}>
+          <Pre emitEvent={collectEvents()}>
             <code className="hljs language-yaml">
               <span className="hljs-attr">key1:</span>{" "}
               <span className="hljs-string">value</span>
@@ -146,7 +147,7 @@ export const CopyVarWithThreePres: Story = {
               <span className="hljs-string">value3</span>
             </code>
           </Pre>
-          <Pre gtag={collectGtagCalls()}>
+          <Pre emitEvent={collectEvents()}>
             <code className="hljs language-yaml">
               <span className="hljs-attr">key4:</span>{" "}
               <span className="hljs-string">value</span>
@@ -184,8 +185,9 @@ key6:
  - value5
  - value6`,
       );
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "yaml",
         // Snippet-level copy button, rather than the copy button for a code
         // line
@@ -202,12 +204,12 @@ export const PreStatsWithTwoCopyButtonClicks: Story = {
     return (
       <PositionProvider>
         <VarsProvider>
-          <Pre gtag={collectGtagCalls()}>
+          <Pre emitEvent={collectEvents()}>
             <code className="hljs language-text">
               <span className="hljs-string">Some text</span>
             </code>
           </Pre>
-          <Pre gtag={collectGtagCalls()}>
+          <Pre emitEvent={collectEvents()}>
             <code className="hljs language-text">
               <span className="hljs-string">More text</span>
             </code>
@@ -223,8 +225,9 @@ export const PreStatsWithTwoCopyButtonClicks: Story = {
     await step("Copy the content", async () => {
       await userEvent.hover(canvas.getByText("Some text"));
       await userEvent.click(canvas.getAllByTestId("copy-button-all")[0]);
-      expect(window.gtagCalls).toHaveLength(1);
-      expect(window.gtagCalls[0].params).toEqual({
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+      	event: "code_copy_button",
         label: "text",
         scope: "snippet",
         code_snippet_index_on_page: 0,
@@ -235,8 +238,9 @@ export const PreStatsWithTwoCopyButtonClicks: Story = {
     await step("Copy the content again", async () => {
       await userEvent.hover(canvas.getByText("Some text"));
       await userEvent.click(canvas.getAllByTestId("copy-button-all")[0]);
-      expect(window.gtagCalls).toHaveLength(2);
-      expect(window.gtagCalls[1].params).toEqual({
+      expect(window.events).toHaveLength(2);
+      expect(window.events[1]).toEqual({
+      	event: "code_copy_button",
         label: "text",
         scope: "snippet",
         code_snippet_index_on_page: 0,

--- a/src/theme/MDXComponents/Pre.tsx
+++ b/src/theme/MDXComponents/Pre.tsx
@@ -20,10 +20,10 @@ const TIMEOUT = 1000;
 interface CodeProps {
   children: ReactNode;
   className?: string;
-  gtag?: (command: string, name: string, params: any) => {};
+  emitEvent?: (command: string, name: string, params: any) => {};
 }
 
-const Pre = ({ children, className, gtag }: CodeProps) => {
+const Pre = ({ children, className, emitEvent }: CodeProps) => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const codeRef = useRef<HTMLDivElement>();
   const buttonRef = useRef<HTMLButtonElement>();
@@ -79,7 +79,7 @@ const Pre = ({ children, className, gtag }: CodeProps) => {
         code_snippet_index_on_page: pos,
         code_snippet_count_on_page: countPres(),
       },
-      gtag: gtag,
+      emitEvent: emitEvent,
     });
 
     if (!navigator.clipboard) {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,3 +1,6 @@
+// emitFunc emits an event to Google Analytics or a custom sink.
+type emitFunc = (name: string, params: any) => {};
+
 /**
  * Analytics event data structure for Google Analytics tracking
  */
@@ -6,8 +9,9 @@ interface AnalyticsEvent {
   event_name: string;
   /** Additional custom data to track with the event */
   custom_parameters?: Record<string, any>;
-  /** Function to submit the data. Intended to replace window.gtag if provided. **/
-  gtag?: (command: string, name: string, params: any) => {};
+  /** Function to submit the data. The default is to push the event to
+   * window.dataLayer so Google Tag Manager can intercept it. **/
+  emitEvent?: emitFunc;
 }
 
 export type { AnalyticsEvent };
@@ -16,14 +20,26 @@ export type { AnalyticsEvent };
 // function unless one is supplied in eventData. If gtag is unavailable, e.g.,
 // in a local preview site, trackEvent logs the event data to the console.
 export const trackEvent = (eventData: AnalyticsEvent): void => {
-  const gtagFn = eventData.gtag || window.gtag || logGtag;
+  let emit: emitFunc;
+  if (eventData.emitEvent) {
+    emit = eventData.emitEvent;
+  } else if (window.dataLayer) {
+    emit = (name: string, params: any) => {
+      window.dataLayer.push({
+        event: name,
+        ...params,
+      });
+    };
+  } else {
+    emit = logEmit;
+  }
 
-  gtagFn("event", eventData.event_name, {
+  emit(eventData.event_name, {
     ...eventData.custom_parameters,
   });
 };
 
-// collectGtagCalls returns a function with the same signature as gtag. The
+// collectEvents returns a function with the same signature as gtag. The
 // function pushes gtag calls to an array field of window so we can make test
 // assertions against them. For this to work, there must be a way to pass this
 // function to a component to call instead of the gtag function from gtag.js,
@@ -32,25 +48,23 @@ export const trackEvent = (eventData: AnalyticsEvent): void => {
 // The length of the window.gtagCalls array indicates the number of gtag calls.
 // Each element contains the gtag command, e.g., "get", "event", or "set", along
 // with the parameters passed to the command.
-export const collectGtagCalls = () => {
+export const collectEvents = () => {
   // Reset the collector so we don't include events from other stories
-  window.gtagCalls = [];
-  return (command: string, name: string, params: any) => {
-    window.gtagCalls.push({
-      command: command,
-      name: name,
-      params: params,
+  window.events = [];
+  return (name: string, params: any) => {
+    window.events.push({
+      event: name,
+      ...params,
     });
   };
 };
 
-// logGtag prints the arguments and payload of a gtag call to the console. Used
+// logEmit prints the arguments and payload of a gtag call to the console. Used
 // for local debugging.
-const logGtag = (command: string, name: string, params: any) => {
+const logEmit = (name: string, params: any) => {
   const gtagCall = {
-    command: command,
-    name: name,
-    params: params,
+    event: name,
+    ...params,
   };
-  console.log("gtag called with: %o", gtagCall);
+  console.log("Google Analytics event emitted: %o", gtagCall);
 };


### PR DESCRIPTION
Push events to `window.dataLayer` if it is available. If it is not, log the event instead. If an event overrides the function for emitting events, e.g., in tests, call that override function.

This way, we can configure Google Tag Manager to intercept events from `window.dataLayer`.