### PR TITLE
Lint for unrecognized frontmatter fields

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -3,6 +3,7 @@ import remarkVariables from "./.remark-build/server/remark-variables.mjs";
 import remarkIncludes from "./.remark-build/server/remark-includes.mjs";
 import remarkNoH1 from "./.remark-build/server/remark-no-h1.mjs";
 import { remarkLintTeleportDocsLinks } from "./.remark-build/server/lint-teleport-docs-links.mjs";
+import { remarkLintFrontmatter } from "./.remark-build/server/lint-frontmatter.mjs";
 import {
   getVersion,
   getVersionRootPath,
@@ -10,6 +11,9 @@ import {
 import { remarkLintPageStructure } from "./.remark-build/server/lint-page-structure.mjs";
 import { loadConfig } from "./.remark-build/server/config-docs.mjs";
 import { updatePathsInIncludes } from "./.remark-build/server/asset-path-helpers.mjs";
+import * as yaml from "yaml";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 const configFix = {
   settings: {
@@ -26,6 +30,11 @@ const configFix = {
   },
   plugins: ["frontmatter", "mdx"],
 };
+
+const allowedFrontmatterConfig = fs.readFileSync(
+  path.join(".", "frontmatter_fields.yaml"),
+  "utf-8",
+);
 
 const configLint = {
   plugins: [
@@ -49,6 +58,7 @@ const configLint = {
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
     ["lint-no-file-name-irregular-characters", false],
+    [remarkLintFrontmatter, yaml.parse(allowedFrontmatterConfig)],
     [
       remarkIncludes, // Lints (!include.ext!) syntax
       {

--- a/frontmatter_fields.yaml
+++ b/frontmatter_fields.yaml
@@ -1,0 +1,33 @@
+# Permitted fields for docs page frontmatter
+allowedFields:
+  # The fields below are used natively by Docusaurus. See the Docusaurus docs:
+  # https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter
+  - custom_edit_url
+  - description
+  - displayed_sidebar
+  - draft
+  - hide_table_of_contents
+  - hide_title
+  - id
+  - image
+  - keywords
+  - last_update
+  - pagination_label
+  - pagination_next
+  - pagination_prev
+  - parse_number_prefixes
+  - sidebar_class_name
+  - sidebar_custom_props
+  - sidebar_key
+  - sidebar_label
+  - sidebar_position
+  - slug
+  - tags
+  - title
+  - toc_max_heading_level
+  - toc_min_heading_level
+  - unlisted
+
+  # The fields below are used in custom components
+  - template
+  - videoBanner

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "unist-util-find": "^3.0.0",
     "unist-util-visit-parents": "^6.0.1",
     "vfile": "^6.0.1",
-    "wait-on": "^9.0.1"
+    "wait-on": "^9.0.1",
+    "yaml": "^2.8.1"
   },
   "browserslist": {
     "production": [

--- a/server/lint-frontmatter.test.ts
+++ b/server/lint-frontmatter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "@jest/globals";
+import { remarkLintFrontmatter } from "./lint-frontmatter";
+import { VFile } from "vfile";
+import { remark } from "remark";
+import mdx from "remark-mdx";
+import remarkFrontmatter from "remark-frontmatter";
+
+const getReasons = (value: string) => {
+  return (
+    remark()
+      .use(mdx as any)
+      // remark-frontmatter is a requirement for using this plugin
+      .use(remarkFrontmatter as any)
+      .use(remarkLintFrontmatter as any, {
+        allowedFields: ["title", "description", "tags"],
+      })
+      .processSync(new VFile({ value, path: "mypath.mdx" }) as any)
+      .messages.map((m) => m.reason)
+  );
+};
+
+describe("server/lint-frontmatter", () => {
+  interface testCase {
+    description: string;
+    input: string;
+    expected: Array<string>;
+  }
+
+  const testCases: Array<testCase> = [
+    {
+      description: "all fields present",
+      input: `---
+title: "My page"
+description: "Description for my page"
+tags: ["one", "two", "three"]
+---
+
+This is a page.`,
+      expected: [],
+    },
+    {
+      description: "no fields present",
+      input: `---
+---
+
+This is a page.`,
+      expected: [],
+    },
+    {
+      description: "missing field",
+      input: `---
+title: "My page"
+description: "Description for my page"
+---
+
+This is a page.`,
+      expected: [],
+    },
+    {
+      description: "one extra field",
+      input: `---
+title: "My page"
+description: "Description for my page"
+labels: ["one", "two", "three"]
+---
+This is a page.`,
+      expected: ["page frontmatter has unrecognized fields: labels"],
+    },
+    {
+      description: "two extra fields",
+      input: `---
+title: "My page"
+descrption: "Description for my page"
+labels: ["one", "two", "three"]
+---
+
+This is a page.`,
+      expected: [
+        "page frontmatter has unrecognized fields: descrption, labels",
+      ],
+    },
+    {
+      description: "invalid frontmatter yaml",
+      input: `---
+title: "My page",
+labels: ["one", "two", "three"]
+---
+
+This is a page.`,
+      expected: [
+        `page has invalid YAML in frontmatter: Unexpected scalar at node end at line 1, column 17:
+
+title: \"My page\",
+                ^
+`,
+      ],
+    },
+    {
+      description: "no frontmatter",
+      input: `This is a page.`,
+      expected: [
+        'the page must begin with a YAML frontmatter document surrounded by "---" separators',
+      ],
+    },
+  ];
+
+  test.each(testCases)("$description", (tc) => {
+    expect(getReasons(tc.input)).toEqual(tc.expected);
+  });
+});

--- a/server/lint-frontmatter.ts
+++ b/server/lint-frontmatter.ts
@@ -1,0 +1,68 @@
+import { lintRule } from "unified-lint-rule";
+import { visit } from "unist-util-visit";
+import type { Node } from "unist";
+import { parse } from "yaml";
+import type { Literal } from "mdast";
+
+const possibleProducts = [
+  "identity-governance",
+  "identity-security",
+  "mwi",
+  "zero-trust",
+  "platform-wide",
+];
+
+const possibleTypes = [
+  "how-to",
+  "conceptual",
+  "get-started",
+  "reference",
+  "faq",
+  "other",
+];
+
+interface LintFrontmatterOptions {
+  allowedFields: Array<string>;
+}
+
+export const remarkLintFrontmatter = lintRule(
+  "remark-lint:frontmatter",
+  (root: Node, vfile, options: LintFrontmatterOptions) => {
+    let hasFrontmatter = false;
+    const { allowedFields } = options;
+    const allowedSet = new Set(allowedFields);
+
+    visit(root, "yaml", (node: Node) => {
+      hasFrontmatter = true;
+
+      // Include frontmatter parsing errors as linting errors.
+      let frontmatter;
+      try {
+        frontmatter = parse((node as Literal).value);
+      } catch (err) {
+        vfile.message(`page has invalid YAML in frontmatter: ${err.message}`);
+        return;
+      }
+
+      // Special case: there are no frontmatter fields. This check only catches
+      // unrecognized fields, so ignore the empty frontmatter object.
+      if (!frontmatter) {
+        return;
+      }
+
+      const actual = new Set(Object.keys(frontmatter));
+      const extraFields = [...actual.difference(allowedSet)];
+      if (extraFields.length > 0) {
+        vfile.message(
+          `page frontmatter has unrecognized fields: ${extraFields.join(", ")}`,
+        );
+      }
+    });
+    if (!hasFrontmatter) {
+      vfile.message(
+        `the page must begin with a YAML frontmatter document surrounded by "---" separators`,
+        root.position,
+      );
+    }
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16542,6 +16542,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
+  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"


### PR DESCRIPTION
Docs pages can include frontmatter fields that are incorrect or no longer used. Docusaurus will build the docs without reading these frontmatter fields - and without throwing an exception - sometimes resulting in unintented behavior.

This change adds a `remark` linter that identifies unrecognized frontmatter fields. The linter loads a configuration file at `frontmatter_fields.yaml` that lists valid frontmatter fields and checks these against the frontmatter fields within each docs page.