### PR TITLE
Restore Var linter and v22 Node requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     ]
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=22.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/server/lint-page-structure.test.ts
+++ b/server/lint-page-structure.test.ts
@@ -396,3 +396,180 @@ Here's some conceptual information.
     });
   });
 });
+
+describe("linting improper Var component use", () => {
+  interface testCase {
+    description: string;
+    input: string;
+    expected: Array<string>;
+  }
+
+  const testCases: Array<testCase> = [
+    {
+      description: `single instance of a Var in a code block`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+This is an introduction.
+
+\`\`\`code
+<Var name="myvar" />
+\`\`\`
+
+`,
+      expected: [
+        'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+      ],
+    },
+    {
+      description: `var in code block with single quotes`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an intro paragraph.
+
+## Prerequisites
+
+- A Teleport cluster
+
+## Concepts
+
+Here's some conceptual information.
+This is an introduction.
+
+\`\`\`code
+<Var name='myvar' />
+\`\`\`
+
+`,
+      expected: [
+        'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+      ],
+    },
+    {
+      description: `single instance of a Var in paragraph`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+`,
+      expected: [
+        'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+      ],
+    },
+    {
+      description: `valid case`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+\`\`\`code
+<Var name="myvar" />
+\`\`\`
+
+`,
+      expected: [],
+    },
+    {
+      description: `multiple violations`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar" />.
+
+\`\`\`code
+<Var name="othervar" />
+\`\`\`
+
+`,
+      expected: [
+        'There is only a single instance of the Var named "myvar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+        'There is only a single instance of the Var named "othervar" on this page. Add another instance, making it explicit that the user can assign the variable. Disable this warning by adding {/* lint ignore page-structure remark-lint */} before this line.',
+      ],
+    },
+    // The apostrophe can trip up regular expression matching
+    {
+      description: `valid case with apostrophe`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="myvar's" />.
+
+\`\`\`code
+<Var name= "myvar's" />
+\`\`\`
+
+`,
+      expected: [],
+    },
+    {
+      description: `valid case with slash`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including <Var name="arn:aws:iam::(=aws.aws_account_id=):role/teleport-docdb-user" />.
+
+\`\`\`code
+<Var name= "arn:aws:iam::(=aws.aws_account_id=):role/teleport-docdb-user" />
+\`\`\`
+
+`,
+      expected: [],
+    },
+    {
+      description: `valid case with list item`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+Here is a list:
+- Item one
+- <Var name="Permission IDs"/>
+
+\`\`\`bash
+cat > variables.auto.tfvars << EOF
+graph_permission_ids    = [<Var name="Permission IDs"/>]
+EOF
+\`\`\`
+
+`,
+      expected: [],
+    },
+    {
+      description: `valid case with inline code`,
+      input: `---
+title: Docs Page
+description: Provides instructions about a feature.
+---
+
+This is an introduction, including \`<Var name="myvar" />\`.
+
+ \`\`\`code
+ <Var name="myvar" />
+ \`\`\`
+
+ `,
+      expected: [],
+    },
+  ];
+
+  test.each(testCases)("$description", (tc) => {
+    expect(getReasons(tc.input)).toEqual(tc.expected);
+  });
+});

--- a/server/lint-page-structure.ts
+++ b/server/lint-page-structure.ts
@@ -1,7 +1,12 @@
 import { lintRule } from "unified-lint-rule";
 import { visit } from "unist-util-visit";
-import type { Heading, Paragraph, Text } from "mdast";
-import type { MdxJsxFlowElement } from "./types-unist";
+import type { Heading, Code, Paragraph, Text } from "mdast";
+import type {
+  MdxJsxFlowElement,
+  EsmNode,
+  MdxAnyElement,
+  MdxastNode,
+} from "./types-unist";
 import type { Node, Parent, Position } from "unist";
 
 const mdxNodeTypes = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
@@ -86,7 +91,7 @@ export const remarkLintPageStructure = lintRule(
       vfile.message(
         "This guide is missing at least one introductory paragraph before the first H2. Use introductory paragraphs to explain the purpose and scope of this guide. " +
           messageSuffix,
-        h2s[0].node.position
+        h2s[0].node.position,
       );
     }
 
@@ -95,9 +100,10 @@ export const remarkLintPageStructure = lintRule(
       vfile.message(
         "In a how-to guide, the first H2-level section must be called `## How it works`. Use this section to include 1-3 paragraphs that describe the high-level architecture of the setup shown in the guide. " +
           messageSuffix,
-        h2s[0].node.position
+        h2s[0].node.position,
       );
     }
+
     const stepNumbers: Array<stepNumber> = [];
     h2s.forEach((heading) => {
       const parts = heading.node.value.match(stepNumberPattern);
@@ -120,9 +126,76 @@ export const remarkLintPageStructure = lintRule(
         vfile.message(
           `This guide has an incorrect sequence of steps - expecting a section called "## Step ${expectedNumerator}/${expectedDenominator}". ` +
             messageSuffix,
-          stepNumbers[i].position
+          stepNumbers[i].position,
         );
       }
     }
-  }
+
+    const varPattern = /<Var[^>]+\/?>/g;
+    const varNameQuotePattern = /name\s*=\s*(["'])/;
+    const varNames = new Map();
+    // The first position of each Var. We only need one since we only use this
+    // for single-instance Vars.
+    const varPositions = new Map();
+
+    visit(root, undefined, (node: Node) => {
+      // Collect the names of Vars that are outside of code blocks.
+      const el = node as MdxAnyElement;
+      if (
+        (node.type == "mdxJsxTextElement" ||
+          node.type == "mdxJsxFlowElement") &&
+        el.name == "Var"
+      ) {
+        el.attributes.forEach((a) => {
+          if (a.name == "name") {
+            if (!varNames.has(a.value)) {
+              varNames.set(a.value, 0);
+              varPositions.set(a.value, el.position);
+              return;
+            }
+            varNames.set(a.value, varNames.get(a.value) + 1);
+          }
+        });
+      }
+
+      // In a code block, Vars are strings, so find them using regular
+      // expressions.
+      const code = node as Code;
+      if (code.type == "code" || code.type == "inlineCode") {
+        const vars = code.value.matchAll(varPattern);
+        vars.forEach((v) => {
+          // Determine if the "name" param uses single or double quotes.
+          const varQuote = v[0].match(varNameQuotePattern);
+          if (!varQuote) {
+            vfile.message(
+              `Var component found without a valid name`,
+              node.position,
+            );
+          }
+
+          // Extract the name. We know that there is a valid name parameter, so
+          // the array indices are guaranteed to be in range.
+          const namePattern = `name\\s*=\\s*${varQuote[1]}([^${varQuote[1]}]+)${varQuote[1]}`;
+          const varName = v[0].match(new RegExp(namePattern))[1];
+          if (!varNames.has(varName)) {
+            varNames.set(varName, 0);
+            varPositions.set(varName, code.position);
+            return;
+          }
+          varNames.set(varName, varNames.get(varName) + 1);
+        });
+      }
+    });
+
+    varNames.forEach((val, key) => {
+      if (val > 0) {
+        return;
+      }
+      vfile.message(
+        `There is only a single instance of the Var named "${key}" on this page. Add another instance, making it explicit that the user can assign the variable. ` +
+          messageSuffix,
+        varPositions.get(key),
+      );
+    });
+  },
 );


### PR DESCRIPTION
This restores the changes that were reverted in #438 and #437:

- Adding a linter for Var component usage, ensuring that every Var has in a page has at least two instances. All violations have been removed from the docs, and there is now a merge_group check to prevent violations from appearing in the docs after a linter PR has been approved.
- Requiring at least Node v22 (the version used on Amplify) to run `yarn` commands in `docs-website`. Linter runs in `gravitational/teleport` now install Node v22.