### PR TITLE
docs: recategorize and expand Inkeep search tabs

### DIFF
--- a/src/hooks/useInkeepSearch.ts
+++ b/src/hooks/useInkeepSearch.ts
@@ -7,6 +7,7 @@ import type {
   InkeepBaseSettings,
   AIChatFunctions,
   SearchFunctions,
+  SourceItem,
 } from '@inkeep/cxkit-react';
 
 interface UseInkeepSearchOptions {
@@ -68,17 +69,26 @@ export function useInkeepSearch(options: UseInkeepSearchOptions = {}) {
     privacyPreferences: {
       optOutAllAnalytics: false,
     },
-    transformSource: (source) => {
-      const isDocs =
-        source.contentType === 'docs' ||
-        source.type === 'documentation';
-      if (!isDocs) {
-        return source;
+    transformSource: (source: SourceItem) => {
+      const { url, tabs } = source;
+      if (url && (url.startsWith('https://www.youtube.com/') || url.includes('goteleport.com/resources/videos'))) {
+        return {
+          ...source,
+          tabs: ['Videos', ...(source.tabs ?? [])],
+          icon: { builtIn: 'IoPlayCircleOutline' },
+        };
       }
+      if (url && url.includes('goteleport.com/docs')) {
+        return {
+          ...source,
+          tabs: ['Docs'],
+          icon: { builtIn: 'IoDocumentTextOutline' },
+        };
+      }
+      const newTabs = tabs && tabs.includes('GitHub') ? ['GitHub'] : ['More'];
       return {
         ...source,
-        tabs: ['Docs', ...(source.tabs ?? [])],
-        icon: { builtIn: 'IoDocumentTextOutline' },
+        tabs: newTabs,
       };
     },
     colorMode: {
@@ -101,6 +111,8 @@ export function useInkeepSearch(options: UseInkeepSearchOptions = {}) {
     tabs: [
       ['Docs', { isAlwaysVisible: true }],
       ['GitHub', { isAlwaysVisible: true }],
+      ['Videos', { isAlwaysVisible: true }],
+      ['More', { isAlwaysVisible: false }],
     ],
     shouldOpenLinksInNewTab: true,
     view: 'dual-pane',


### PR DESCRIPTION
Currently the Inkeep Search has two categories `Docs` and `GitHub`. `Docs` is essentially a dumping ground for Docs, Blog posts, Videos, etc. and muddies up the search results for people search our docs.

This commit adds two new category tabs, `Videos` and `More`, to the Inkeep search results. This will categorize `Docs`,`GitHub`, and `Videos`, in their respective tabs and content, and everything else (blogs, etc.) will fall into the More tab.

Original external PR was authored by Sarah from Inkeep - #418. This PR was created internally in order to allow for Amplify Preview.