### PR TITLE
Allow label-only `DocCardList`s

### DIFF
--- a/src/theme/DocCardList/index.tsx
+++ b/src/theme/DocCardList/index.tsx
@@ -12,7 +12,14 @@ import type {
 } from "@docusaurus/plugin-content-docs";
 import { categoryHrefToDocID } from "./href-to-id";
 
-function DocCardListForCurrentSidebarCategory({ className }: Props) {
+interface DocCardListProps extends Props {
+  kind: "labelOnly" | undefined;
+}
+
+function DocCardListForCurrentSidebarCategory({
+  className,
+  kind,
+}: DocCardListProps) {
   let category: PropSidebarItemCategory;
   // DocCardList only works if the current page has a sidebar entry, but the
   // error Docusaurus currently throws is difficult to understand. Throw an
@@ -27,11 +34,13 @@ function DocCardListForCurrentSidebarCategory({ className }: Props) {
       "The current page does not have a corresponding sidebar entry, so it is not possible to use DocCardList. Make sure that the page is represented on the sidebar.",
     );
   }
-  return <DocCardList items={category.items} className={className} />;
+  return (
+    <DocCardList kind={kind} items={category.items} className={className} />
+  );
 }
 
-export default function DocCardList(props: Props): JSX.Element {
-  const { items, className } = props;
+export default function DocCardList(props: DocCardListProps): JSX.Element {
+  const { items, className, kind } = props;
   if (!items) {
     return <DocCardListForCurrentSidebarCategory {...props} />;
   }
@@ -60,7 +69,8 @@ export default function DocCardList(props: Props): JSX.Element {
     <ul className={className}>
       {filteredItems.map((item, index) => (
         <li key={index}>
-          <a href={item.href}>{item.label}</a>: {item.description}
+          <a href={item.href}>{item.label}</a>
+          {kind == "labelOnly" || ": " + item.description}
         </li>
       ))}
     </ul>


### PR DESCRIPTION
Currently, the `DocCardList` component displays a list of items in which each item contains the label and description of each page in a sidebar section.

This change adds the possibility of including a `kind` prop in a `DocCardList` that changes its formatting. The only supported value, `labelOnly`, only lists the label of each guide. This is helpful in situations in which descriptions are repetitive and don't provide useful information on an index page.

If no `kind` is provided, the `DocCardList` lists labels and descriptions as usual.

Another possibility would be to make this prop a `labelOnly` Boolean, but it seems likely that we'll add other formatting options in the future.