### PR TITLE
Add missing description field to Resources

### DIFF
--- a/src/components/Pages/Homepage/Resources/Resources.module.css
+++ b/src/components/Pages/Homepage/Resources/Resources.module.css
@@ -24,10 +24,21 @@
   width: 100%;
 }
 
+.header {
+  &.hasTitle {
+    margin-bottom: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
+
+    &.docVariant {
+      margin-bottom: var(--m-3);
+    }
+  }
+}
+
 .resourcesTitle {
   font-size: var(--fs-header-1);
-  margin-bottom: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
+  margin-bottom: 0;
   margin-top: 0;
+  line-height: 1.5;
 
   @media (max-width: 576px) {
     font-size: 1.5rem;
@@ -35,7 +46,6 @@
 
   &.docVariant {
     font-size: var(--fs-header-4);
-    margin-bottom: var(--m-3);
 
     @media (--md-scr) {
       font-size: 1.375rem; /* 22px */
@@ -44,6 +54,23 @@
     @media (--lg-scr) {
       font-size: var(--fs-header-3);
     }
+  }
+}
+
+.description {
+  color: var(--color-foreground-slightly-muted);
+  font-size: var(--fs-text-lg);
+  line-height: 1.625;
+  margin-bottom: 0;
+  font-weight: var(--fw-medium);
+
+  @media (--md-scr) {
+    line-height: 1.75;
+  }
+
+  @media (--lg-scr) {
+    font-size: var(--fs-text-xl);
+    line-height: 1.66667;
   }
 }
 

--- a/src/components/Pages/Homepage/Resources/Resources.tsx
+++ b/src/components/Pages/Homepage/Resources/Resources.tsx
@@ -17,6 +17,7 @@ interface Resource {
 interface ResourcesProps {
   className?: string;
   title?: string;
+  description?: string;
   variant?: "homepage" | "doc";
   desktopColumnsCount?: number;
   resources: Resource[];
@@ -110,6 +111,7 @@ const ResourceCard: React.FC<Resource> = ({
 const Resources: React.FC<ResourcesProps> = ({
   className = "",
   title = "Enroll resources",
+  description,
   variant = "homepage",
   desktopColumnsCount = 4,
   resources,
@@ -124,15 +126,23 @@ const Resources: React.FC<ResourcesProps> = ({
       })}
     >
       <div className={styles.resourcesContainer}>
-        {title && (
-          <Heading
-            className={cn(styles.resourcesTitle, {
-              [styles.docVariant]: variant === "doc",
-            })}
-          >
-            {title}
-          </Heading>
-        )}
+        <div
+          className={cn(styles.header, {
+            [styles.hasTitle]: !!title,
+            [styles.docVariant]: variant === "doc",
+          })}
+        >
+          {title && (
+            <Heading
+              className={cn(styles.resourcesTitle, {
+                [styles.docVariant]: variant === "doc",
+              })}
+            >
+              {title}
+            </Heading>
+          )}
+          {description && <p className={styles.description}>{description}</p>}
+        </div>
         <div
           className={styles.resourcesGrid}
           style={


### PR DESCRIPTION
This PR adds the `description` property to the `Resources` component. The property was mistakenly not added to the component previously. Fixes the issue with the description not showing up in [the Databases page update PR](https://github.com/gravitational/teleport/pull/61353)