### PR TITLE
Update CSS for DropdownMenu to scope link styles under .panel class

### DIFF
--- a/src/components/DropdownMenu/NavPanel.module.css
+++ b/src/components/DropdownMenu/NavPanel.module.css
@@ -77,7 +77,7 @@
   margin: 0;
 }
 
-a {
+.panel a {
   color: inherit;
   text-decoration: none;
   padding: 6px 0;


### PR DESCRIPTION
A straightforward solution to prevent navigation styles from overriding global link styles. 