### PR TITLE
Add `ChangelogLink`

### DIFF
--- a/src/components/ChangelogLink/index.tsx
+++ b/src/components/ChangelogLink/index.tsx
@@ -1,0 +1,23 @@
+import {
+  useActiveDocContext,
+} from "@docusaurus/plugin-content-docs/client";
+import Link from "@docusaurus/Link";
+import useGlobalData from "@docusaurus/useGlobalData";
+
+export const ChangelogLink = () => {
+  const { activeVersion, alternateDocVersions } = useActiveDocContext();
+  const isCurrent = activeVersion.name == "current";
+
+  return (
+    <>
+      {isCurrent || (
+        <p>
+          This changelog includes release notes for version{" "}
+          {activeVersion.label}. For all release notes, visit the{" "}
+          <Link href={alternateDocVersions.current.path}>edge version</Link> of
+          the changelog.
+        </p>
+      )}
+    </>
+  );
+};

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -25,11 +25,13 @@ import Tile from "/src/components/Tile";
 import TileGrid from "/src/components/TileGrid";
 import { Var } from "/src/components/Variables";
 import EnterpriseFeatureCallout from "/src/components/EnterpriseFeatureCallout";
+import { ChangelogLink } from "/src/components/ChangelogLink";
 
 const MDXComponents: MDXComponentsObject = {
   ...OriginalMDXComponents,
   Details: MDXDetails,
   DocCardList: DocCardList,
+  ChangelogLink,
   Head,
   Icon,
   TabItem,


### PR DESCRIPTION
The `ChangelogLink` component displays a link to the edge version of the changelog if the user is not currently viewing that version. Since we are moving to a process in which the changelogs on `gravitational/teleport` release branches only includes release notes for their corresponding major versions, this makes it clear for users where they can find all release notes.