### PR TITLE
Allow for Boolean `enterprise` frontmatter values

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "18.x",
-      "branch": "branch/v18",
+      "branch": "paul.gottschling/2025-12-19-enterprise-fm",
       "isDefault": true
     },
     {

--- a/src/components/ExclusivityBanner/ExclusivityBanner.tsx
+++ b/src/components/ExclusivityBanner/ExclusivityBanner.tsx
@@ -25,47 +25,48 @@ const ExclusivityBanner: React.FC = () => {
     }
   }, [dismissed]);
 
-  if (exclusiveFeature) {
-    return (
-      <div className={styles.exclusivityWrapper}>
-        <div
-          className={cn(styles.exclusivityBanner, {
-            [styles.visible]: !dismissed,
-          })}
-        >
-          <div className={styles.inner}>
-            <div className={styles.content}>
-              <Icon size="sm-md" name="rocketLaunch" />
-              <p>
-                {exclusiveFeature} is available only with Teleport Enterprise.{" "}
-                <a href="https://goteleport.com/signup/">
-                  Start your free trial.
-                </a>
-              </p>
-            </div>
-            <Button
-              as="button"
-              onClick={() => setDismissed(true)}
-              className={styles.hideButton}
-            >
-              Hide
-            </Button>
+  if (!exclusiveFeature) {
+    return null;
+  }
+
+  return (
+    <div className={styles.exclusivityWrapper}>
+      <div
+        className={cn(styles.exclusivityBanner, {
+          [styles.visible]: !dismissed,
+        })}
+      >
+        <div className={styles.inner}>
+          <div className={styles.content}>
+            <Icon size="sm-md" name="rocketLaunch" />
+            <p>
+              {exclusiveFeature} is available only with Teleport Enterprise.{" "}
+              <a href="https://goteleport.com/signup/">
+                Start your free trial.
+              </a>
+            </p>
           </div>
-        </div>
-        <div
-          role="button"
-          onClick={() => setDismissed(false)}
-          className={cn(styles.exclusivityBadge, {
-            [styles.visible]: dismissed,
-          })}
-        >
-          <Icon size="sm-md" name="rocketLaunch" />
-          Start your free trial
+          <Button
+            as="button"
+            onClick={() => setDismissed(true)}
+            className={styles.hideButton}
+          >
+            Hide
+          </Button>
         </div>
       </div>
-    );
-  }
-  return null;
+      <div
+        role="button"
+        onClick={() => setDismissed(false)}
+        className={cn(styles.exclusivityBadge, {
+          [styles.visible]: dismissed,
+        })}
+      >
+        <Icon size="sm-md" name="rocketLaunch" />
+        Start your free trial
+      </div>
+    </div>
+  );
 };
 
 export default ExclusivityBanner;

--- a/src/components/ExclusivityBanner/context.ts
+++ b/src/components/ExclusivityBanner/context.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 
 interface ExclusivityContextType {
-  exclusiveFeature?: string;
+  exclusiveFeature?: string | boolean;
 }
 
 const ExclusivityContext = createContext<ExclusivityContextType | null>(null);

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -51,12 +51,18 @@ function useDocTOC(removeTOCSidebar: boolean) {
   };
 }
 
-function usePageExclusivityBanner() {
+function usePageExclusivityBanner(): string | boolean {
   const { frontMatter } = useDoc();
+  const { enterprise } = (frontMatter as any);
+  if (!enterprise) {
+    return { exclusiveFeature: false };
+  }
+  let capability = "This capability";
+  if (typeof enterprise === "string") {
+    capability = enterprise;
+  }
 
-  const exclusiveFeature = (frontMatter as any).enterprise;
-
-  return { exclusiveFeature };
+  return { exclusiveFeature: capability };
 }
 
 export default function DocItemLayout({ children }: Props): JSX.Element {
@@ -93,7 +99,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
           className={clsx(
             "col",
             !docTOC.hidden && !docTOC.removed && styles.docItemCol,
-            fullWidth && styles.largeColumnPadding
+            fullWidth && styles.largeColumnPadding,
           )}
         >
           {unlisted && <Unlisted />}


### PR DESCRIPTION
The `enterprise` frontmatter field currently has a string value, and uses the string as-is when rendering the exclusivity banner. This makes it difficult to add this frontmatter field in bulk, since we need to determine a value for this field for each page in the docs that requires it.

This change allows us to use either a Boolean or a string for the `enterprise` frontmatter field. If the value is a Boolean, the exclusivity banner displays "This feature" for the feature name.