### PR TITLE
docs: adjusting ThumbsFeedback logic

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,10 +1,19 @@
 import type { StorybookConfig } from "@storybook/react-webpack5";
+import path from "path";
 
 const config: StorybookConfig = {
   framework: "@storybook/react-webpack5",
   stories: ["../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: ["@storybook/addon-essentials"],
   webpackFinal: async (config) => {
+    // Mock @docusaurus/router for Storybook
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@docusaurus/router": path.resolve(__dirname, "./mocks/docusaurus-router.ts"),
+      "@site": path.resolve(__dirname, ".."),
+    };
+
     config.module?.rules?.push({
       test: /\.css$/,
       use: {

--- a/.storybook/mocks/docusaurus-router.ts
+++ b/.storybook/mocks/docusaurus-router.ts
@@ -1,0 +1,1 @@
+export const useLocation = () => ({ pathname: "/test-page" });

--- a/src/components/ThumbsFeedback/ThumbsFeedback.stories.tsx
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+import { expect } from "@storybook/test";
+import React, { useState, useMemo } from "react";
+import ThumbsFeedback from "./ThumbsFeedback";
+import ThumbsFeedbackContext from "./context";
+import { FeedbackType } from "./types";
+import { collectEvents } from "@site/src/utils/analytics";
+
+// Wrapper component that provides the context
+const ThumbsFeedbackWrapper: React.FC<{
+  pagePosition?: "top" | "bottom";
+}> = ({ pagePosition = "bottom" }) => {
+  const [feedback, setFeedback] = useState<FeedbackType | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const emitEvent = useMemo(() => collectEvents(), []);
+
+  return (
+    <ThumbsFeedbackContext.Provider
+      value={{ feedback, setFeedback, isSubmitted, setIsSubmitted }}
+    >
+      <ThumbsFeedback pagePosition={pagePosition} emitEvent={emitEvent} />
+    </ThumbsFeedbackContext.Provider>
+  );
+};
+
+export const InitialState = () => <ThumbsFeedbackWrapper />;
+
+const meta: Meta<typeof ThumbsFeedback> = {
+  title: "components/ThumbsFeedback",
+  component: InitialState,
+  decorators: [
+    (Story) => {
+      localStorage.removeItem("feedback_given_paths");
+      return <Story />;
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThumbsFeedback>;
+
+export const PositiveFeedbackClick: Story = {
+  render: () => <ThumbsFeedbackWrapper />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click thumbs up button", async () => {
+      await userEvent.click(canvas.getByLabelText("Yes, this page is helpful"));
+      expect(
+        canvas.getByText("Great! Is there anything we can improve?")
+      ).toBeInTheDocument();
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "docs_feedback_thumbs_up",
+      });
+    });
+  },
+};
+
+export const PositiveFeedbackSubmit: Story = {
+  render: () => <ThumbsFeedbackWrapper />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click thumbs up button", async () => {
+      await userEvent.click(canvas.getByLabelText("Yes, this page is helpful"));
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "docs_feedback_thumbs_up",
+      });
+    });
+
+    await step("Enter feedback comment", async () => {
+      const textarea = canvas.getByPlaceholderText(
+        "Tell us more about your experience"
+      );
+      await userEvent.type(textarea, "Great documentation!");
+      expect(textarea).toHaveValue("Great documentation!");
+    });
+
+    await step("Submit feedback", async () => {
+      await userEvent.click(canvas.getByText("Submit"));
+      expect(window.events).toHaveLength(2);
+      expect(window.events[1]).toEqual({
+        event: "docs_feedback_comment_thumbs_up",
+        comment_text: "Great documentation!",
+      });
+    });
+  },
+};
+
+export const NegativeFeedbackClick: Story = {
+  render: () => <ThumbsFeedbackWrapper />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click thumbs down button", async () => {
+      await userEvent.click(
+        canvas.getByLabelText("No, this page is not helpful")
+      );
+      expect(
+        canvas.getByText("How can we improve this page?")
+      ).toBeInTheDocument();
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "docs_feedback_thumbs_down",
+      });
+    });
+  },
+};
+
+export const NegativeFeedbackSubmit: Story = {
+  render: () => <ThumbsFeedbackWrapper />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click thumbs down button", async () => {
+      await userEvent.click(
+        canvas.getByLabelText("No, this page is not helpful")
+      );
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "docs_feedback_thumbs_down",
+      });
+    });
+
+    await step("Enter feedback comment", async () => {
+      const textarea = canvas.getByPlaceholderText(
+        "Tell us more about your experience"
+      );
+      await userEvent.type(textarea, "Missing examples");
+      expect(textarea).toHaveValue("Missing examples");
+    });
+
+    await step("Submit feedback", async () => {
+      await userEvent.click(canvas.getByText("Submit"));
+      expect(window.events).toHaveLength(2);
+      expect(window.events[1]).toEqual({
+        event: "docs_feedback_comment_thumbs_down",
+        comment_text: "Missing examples",
+      });
+    });
+  },
+};


### PR DESCRIPTION
This PR fixes some logic in ThumbsFeedback that caused the for submission never to emit.

The trackEvent call for comment submissions is placed in a code path that was never reached. When a user clicks thumbs up/down, a localStorage entry is created. When the comment form is submitted, handleSubmit would always find that existing entry so would return early before reaching the trackEvent GA emit call.

This PR moves the trackEvent call into the else if (foundCurrentPath) block where the actual comment submission logic executes, and since there is never a case where a form would be submitted without a localStorage entry, the unreachable code below it is also removed.

Storybook added. Because @docusaurus/router is used in this component, we had to add a mock for it as Storybook doesn't know what that is.