### PR TITLE
Update the details component styling

### DIFF
--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -32,9 +32,13 @@
   --color-tonal-primary-1: rgba(81, 47, 201, 0.18);
   --color-tonal-primary-2: rgba(81, 47, 201, 0.25);
   --color-interactive-tonal-neutral-dark-0: rgba(255, 255, 255, 0.07);
+  --color-interactive-tonal-accent-informational-0: rgba(0, 115, 186, 0.1);
+  --color-interactive-tonal-accent-informational-1: rgba(0, 115, 186, 0.18);
+  --color-interactive-tonal-accent-informational-2: rgba(0, 115, 186, 0.25);
 
   --color-interactive-primary: #9f85ff;
   --color-interactive-primary-hover: #4126a1;
+  --interactive-accent-link-default: #0073ba;
   --color-background-depth-2: #fbfbfc;
   --color-data-purple-tertiary: #b9a6ff;
   --color-data-caribbean-tertiary: #2effd5;

--- a/src/theme/MDXComponents/Details.module.css
+++ b/src/theme/MDXComponents/Details.module.css
@@ -1,0 +1,48 @@
+.details {
+  color: var(--color-black);
+  box-shadow: unset;
+  border-radius: var(--m-1);
+  padding: 0;
+  border: none;
+  border-left: 3px solid var(--interactive-accent-link-default);
+  margin-bottom: var(--m-4);
+
+  summary {
+    margin-left: 56px;
+    display: flex;
+    align-items: center;
+    position: relative;
+    padding: var(--m-1-5) var(--m-2) var(--m-1-5) 0;
+    font-weight: var(--fw-bold);
+    &::before {
+      width: 24px;
+      height: 24px;
+      margin-right: var(--m-1-5);
+      border: unset;
+      left: -12px;
+      top: 50%;
+      transform: translate(-100%, -50%) !important;
+      background-repeat: no-repeat;
+      transition: background-image var(--t-fast) ease-in-out;
+      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12.75 3.75C12.75 3.33579 12.4142 3 12 3C11.5858 3 11.25 3.33579 11.25 3.75V11.25H3.75C3.33579 11.25 3 11.5858 3 12C3 12.4142 3.33579 12.75 3.75 12.75H11.25V20.25C11.25 20.6642 11.5858 21 12 21C12.4142 21 12.75 20.6642 12.75 20.25V12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H12.75V3.75Z" fill="%230073BA"/></svg>');
+    }
+  }
+
+  & > div {
+    & > div {
+      margin: 0;
+      padding: var(--m-2);
+      border-top-color: var(--color-interactive-tonal-accent-informational-2);
+    }
+  }
+
+  &[data-collapsed="false"] {
+    summary {
+      &::before {
+        background-repeat: no-repeat;
+        background-position: center;
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 12C3 11.5858 3.33579 11.25 3.75 11.25H20.25C20.6642 11.25 21 11.5858 21 12C21 12.4142 20.6642 12.75 20.25 12.75H3.75C3.33579 12.75 3 12.4142 3 12Z" fill="%230073BA"/></svg>');
+      }
+    }
+  }
+}

--- a/src/theme/MDXComponents/Details.tsx
+++ b/src/theme/MDXComponents/Details.tsx
@@ -1,26 +1,15 @@
-import React, {
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react";
-import Details from "@theme/Details";
-import type { Props } from "@theme/MDXComponents/Details";
+import React, { type ReactNode } from "react";
+import Details from "@theme-original/MDXComponents/Details";
+import type DetailsType from "@theme/MDXComponents/Details";
+import type { WrapperProps } from "@docusaurus/types";
 import styles from "./Details.module.css";
 
-export default function MDXDetails(props: Props): ReactNode {
-  const items = React.Children.toArray(props.children);
-  // Split summary item from the rest to pass it as a separate prop to the
-  // Details theme component
+type Props = WrapperProps<typeof DetailsType>;
 
-  const summary = items.find(
-    (item): item is ReactElement<ComponentProps<"summary">> =>
-      React.isValidElement(item) && item.type === "summary"
-  );
-  const children = <>{items.filter((item) => item !== summary)}</>;
-
+export default function DetailsWrapper(props: Props): ReactNode {
   return (
-    <Details {...props} summary={summary} className={styles.details}>
-      {children}
-    </Details>
+    <>
+      <Details {...props} className={styles.details} />
+    </>
   );
 }

--- a/src/theme/MDXComponents/Details.tsx
+++ b/src/theme/MDXComponents/Details.tsx
@@ -1,0 +1,26 @@
+import React, {
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import Details from "@theme/Details";
+import type { Props } from "@theme/MDXComponents/Details";
+import styles from "./Details.module.css";
+
+export default function MDXDetails(props: Props): ReactNode {
+  const items = React.Children.toArray(props.children);
+  // Split summary item from the rest to pass it as a separate prop to the
+  // Details theme component
+
+  const summary = items.find(
+    (item): item is ReactElement<ComponentProps<"summary">> =>
+      React.isValidElement(item) && item.type === "summary"
+  );
+  const children = <>{items.filter((item) => item !== summary)}</>;
+
+  return (
+    <Details {...props} summary={summary} className={styles.details}>
+      {children}
+    </Details>
+  );
+}


### PR DESCRIPTION
This PR updates the `<details>` component styles according to [the SSO Figma design](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=7083-15911).

- Change background color
- Adjust padding
- Change the closed/collapsed icon to a plus / minus
- Added some variables