### PR TITLE
docs: adding paragraph spacing to Checkpoints

### DIFF
--- a/src/components/Checkpoint/Checkpoint.module.css
+++ b/src/components/Checkpoint/Checkpoint.module.css
@@ -6,10 +6,6 @@
   border-radius: var(--m-1);
   border: 2px solid var(--color-tonal-neutral-0);
 
-  p {
-    margin: 0;
-  }
-
   .header {
     display: flex;
     align-items: center;
@@ -21,6 +17,7 @@
     font-weight: var(--fw-bold);
     line-height: 1.5;
     color: var(--color-black);
+    margin-bottom: 0;
   }
 
   .header,


### PR DESCRIPTION
In this commit, we are adding the default margin back to the items in the Checkpoint components.

Currently, margin is removed for paragraphs in the Checkpoint components. But if a Troubleshooting item in the checkpoint has a code snippet (or any text nested in a list item), our default margin needs to be applied so as to be consistent with how it is used/looks regularly in our docs.  This PR removes the 0 `p` margin as it's not needed. 

Also when we remove this margin, the Heading gets the margin back which causes the center Flex to be off, so have to set that to 0 so as to center with the Flag svg Flex. 

Can also see from the [active checkpoints](https://travis-rodgers-adding-paragraph-spacing-to-checkpoints.d2mrezcly5gcqm.amplifyapp.com/docs/get-started/deploy-community/) that the styling is not affected in any other way with this change.

See before (left) and after (right)

<img width="2000" height="799" alt="Screenshot 2026-01-14 at 10 46 44 AM" src="https://github.com/user-attachments/assets/43ec703d-a60c-47ca-9ef8-ad37bab6dfb1" />
