### PR TITLE
Page-level exclusivity banner style update

### DIFF
--- a/src/components/ExclusivityBanner/ExclusivityBanner.module.css
+++ b/src/components/ExclusivityBanner/ExclusivityBanner.module.css
@@ -28,11 +28,11 @@
 
     .inner {
       width: 100%;
-      background-color: var(--color-tonal-primary-0);
+      background-color: var(--color-dark-purple);
       display: flex;
       align-items: center;
       padding: var(--m-1) var(--m-2);
-      color: var(--color-dark-purple);
+      color: var(--color-white);
       font-size: var(--fs-text-md);
       justify-content: space-between;
 
@@ -49,6 +49,7 @@
 
       svg {
         min-width: 20px;
+        filter: brightness(0) invert(1);
       }
 
       p {
@@ -57,6 +58,7 @@
 
       a {
         font-weight: var(--fw-bold);
+        color: inherit;
         text-decoration: underline;
       }
     }
@@ -67,10 +69,12 @@
       border-radius: 4px;
       background-color: transparent;
       border-color: transparent;
-      color: var(--color-dark-purple);
+      color: var(--white);
+      transition: background-color 0.2s ease-in-out;
 
       &:hover {
-        background-color: var(--color-tonal-primary-0);
+        background-color: var(--color-tonal-neutral-2);
+        box-shadow: none;
       }
 
       @media (--md-scr) {


### PR DESCRIPTION
This PR adjusts the background color and the text color of `ExclusivityBanner` according to the [Figma design](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=7877-18237&t=Nxr4vBMuRNaTc4Fk-4).