### PR TITLE
FAQ page style changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
     },
     {
       "name": "18.x",
-      "branch": "branch/v18",
+      "branch": "aatuvai/faq-page",
+      "repo_path": "aatuvai/teleport",
       "isDefault": true
     },
     {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -95,3 +95,27 @@ button {
     line-height: 1.66667;
   }
 }
+
+.tabs {
+  border-radius: 60px;
+  background: var(--color-tonal-neutral-0);
+  width: fit-content;
+  padding: var(--m-1);
+
+  .tabs__item {
+    padding: var(--m-1) var(--m-3);
+    border-radius: 36px;
+    font-size: var(--fs-text-md);
+    font-weight: var(--fw-regular);
+    line-height: 1.42857;
+    display: flex;
+    align-items: center;
+    border-bottom: unset;
+    transition: all 0.2s ease-in-out;
+
+    &.tabs__item--active {
+      background: var(--color-dark-purple);
+      color: var(--color-white);
+    }
+  }
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -32,9 +32,13 @@
   --color-tonal-primary-1: rgba(81, 47, 201, 0.18);
   --color-tonal-primary-2: rgba(81, 47, 201, 0.25);
   --color-interactive-tonal-neutral-dark-0: rgba(255, 255, 255, 0.07);
+  --color-interactive-tonal-accent-informational-0: rgba(0, 115, 186, 0.1);
+  --color-interactive-tonal-accent-informational-1: rgba(0, 115, 186, 0.18);
+  --color-interactive-tonal-accent-informational-2: rgba(0, 115, 186, 0.25);
 
   --color-interactive-primary: #9f85ff;
   --color-interactive-primary-hover: #4126a1;
+  --interactive-accent-link-default: #0073ba;
   --color-background-depth-2: #fbfbfc;
   --color-data-purple-tertiary: #b9a6ff;
   --color-data-purple-secondary: #6f4ced;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -40,6 +40,7 @@
   --color-interactive-primary-hover: #4126a1;
   --interactive-accent-link-default: #0073ba;
   --color-background-depth-2: #fbfbfc;
+  --color-background-depth-3: #f1f2f4;
   --color-data-purple-tertiary: #b9a6ff;
   --color-data-purple-secondary: #6f4ced;
   --color-data-caribbean-tertiary: #2effd5;

--- a/src/theme/MDXComponents/Details.module.css
+++ b/src/theme/MDXComponents/Details.module.css
@@ -3,7 +3,6 @@
   box-shadow: unset;
   border-radius: var(--m-1);
   padding: 0;
-  font-size: var(--fs-text-xl);
   margin-bottom: var(--m-2);
   border: none;
   border-left: 3px solid var(--interactive-accent-link-default);

--- a/src/theme/MDXComponents/Details.module.css
+++ b/src/theme/MDXComponents/Details.module.css
@@ -3,18 +3,17 @@
   box-shadow: unset;
   border-radius: var(--m-1);
   padding: 0;
-  border: 1px solid var(--color-tonal-neutral-1);
-  background-color: var(--color-background-depth-2);
-  margin-bottom: var(--m-1);
+  font-size: var(--fs-text-xl);
+  margin-bottom: var(--m-2);
+  border: none;
+  border-left: 3px solid var(--interactive-accent-link-default);
 
   summary {
     display: flex;
     align-items: center;
     position: relative;
     padding: var(--m-1-5) var(--m-2) var(--m-1-5) 56px;
-    background-color: var(--color-background-depth-3);
     border-bottom: unset;
-    font-weight: var(--fw-bold);
     border-radius: var(--m-1) var(--m-1) 0 0;
     &::before {
       width: 24px;
@@ -27,7 +26,7 @@
       background-repeat: no-repeat;
       background-position: center;
       transition: background-image var(--t-fast) ease-in-out;
-      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6.5 0.5C6.5 0.223858 6.27614 0 6 0C5.72386 0 5.5 0.223858 5.5 0.5V5.5H0.5C0.223858 5.5 0 5.72386 0 6C0 6.27614 0.223858 6.5 0.5 6.5H5.5V11.5C5.5 11.7761 5.72386 12 6 12C6.27614 12 6.5 11.7761 6.5 11.5V6.5H11.5C11.7761 6.5 12 6.27614 12 6C12 5.72386 11.7761 5.5 11.5 5.5H6.5V0.5Z" fill="black" fill-opacity="0.54"/></svg>');
+      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12.75 3.75C12.75 3.33579 12.4142 3 12 3C11.5858 3 11.25 3.33579 11.25 3.75V11.25H3.75C3.33579 11.25 3 11.5858 3 12C3 12.4142 3.33579 12.75 3.75 12.75H11.25V20.25C11.25 20.6642 11.5858 21 12 21C12.4142 21 12.75 20.6642 12.75 20.25V12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H12.75V3.75Z" fill="%230073BA"/></svg>');
     }
   }
 
@@ -35,14 +34,44 @@
     & > div {
       margin: 0;
       padding: var(--m-2);
-      border-top: 1px solid var(--color-tonal-neutral-1);
+      border-top-color: var(--color-interactive-tonal-accent-informational-2);
     }
   }
 
   &[data-collapsed="false"] {
     summary {
       &::before {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 8C2 7.72386 2.22386 7.5 2.5 7.5H13.5C13.7761 7.5 14 7.72386 14 8C14 8.27614 13.7761 8.5 13.5 8.5H2.5C2.22386 8.5 2 8.27614 2 8Z" fill="black" fill-opacity="0.54"/></svg>');
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 12C3 11.5858 3.33579 11.25 3.75 11.25H20.25C20.6642 11.25 21 11.5858 21 12C21 12.4142 20.6642 12.75 20.25 12.75H3.75C3.33579 12.75 3 12.4142 3 12Z" fill="%230073BA"/></svg>');
+      }
+    }
+  }
+
+  &.neutral {
+    margin-bottom: var(--m-1);
+    border: 1px solid var(--color-tonal-neutral-1);
+    background-color: var(--color-background-depth-2);
+
+    summary {
+      background-color: var(--color-background-depth-3);
+      font-weight: var(--fw-bold);
+      &::before {
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6.5 0.5C6.5 0.223858 6.27614 0 6 0C5.72386 0 5.5 0.223858 5.5 0.5V5.5H0.5C0.223858 5.5 0 5.72386 0 6C0 6.27614 0.223858 6.5 0.5 6.5H5.5V11.5C5.5 11.7761 5.72386 12 6 12C6.27614 12 6.5 11.7761 6.5 11.5V6.5H11.5C11.7761 6.5 12 6.27614 12 6C12 5.72386 11.7761 5.5 11.5 5.5H6.5V0.5Z" fill="black" fill-opacity="0.54"/></svg>');
+      }
+    }
+
+    &[data-collapsed="false"] {
+      summary {
+        &::before {
+          background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 8C2 7.72386 2.22386 7.5 2.5 7.5H13.5C13.7761 7.5 14 7.72386 14 8C14 8.27614 13.7761 8.5 13.5 8.5H2.5C2.22386 8.5 2 8.27614 2 8Z" fill="black" fill-opacity="0.54"/></svg>');
+        }
+      }
+    }
+
+    & > div {
+      & > div {
+        margin: 0;
+        padding: var(--m-2);
+        border-top: 1px solid var(--color-tonal-neutral-1);
       }
     }
   }

--- a/src/theme/MDXComponents/Details.module.css
+++ b/src/theme/MDXComponents/Details.module.css
@@ -1,0 +1,48 @@
+.details {
+  color: var(--color-black);
+  box-shadow: unset;
+  border-radius: var(--m-1);
+  padding: 0;
+  border: none;
+  border-left: 3px solid var(--interactive-accent-link-default);
+  margin-bottom: var(--m-4);
+
+  summary {
+    margin-left: 56px;
+    display: flex;
+    align-items: center;
+    position: relative;
+    padding: var(--m-1-5) var(--m-2) var(--m-1-5) 0;
+    font-weight: var(--fw-bold);
+    &::before {
+      width: 24px;
+      height: 24px;
+      margin-right: var(--m-1-5);
+      border: unset;
+      left: -12px;
+      top: 50%;
+      transform: translate(-100%, -50%) !important;
+      background-repeat: no-repeat;
+      transition: background-image var(--t-fast) ease-in-out;
+      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12.75 3.75C12.75 3.33579 12.4142 3 12 3C11.5858 3 11.25 3.33579 11.25 3.75V11.25H3.75C3.33579 11.25 3 11.5858 3 12C3 12.4142 3.33579 12.75 3.75 12.75H11.25V20.25C11.25 20.6642 11.5858 21 12 21C12.4142 21 12.75 20.6642 12.75 20.25V12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H12.75V3.75Z" fill="%230073BA"/></svg>');
+    }
+  }
+
+  & > div {
+    & > div {
+      margin: 0;
+      padding: var(--m-2);
+      border-top-color: var(--color-interactive-tonal-accent-informational-2);
+    }
+  }
+
+  &[data-collapsed="false"] {
+    summary {
+      &::before {
+        background-repeat: no-repeat;
+        background-position: center;
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 12C3 11.5858 3.33579 11.25 3.75 11.25H20.25C20.6642 11.25 21 11.5858 21 12C21 12.4142 20.6642 12.75 20.25 12.75H3.75C3.33579 12.75 3 12.4142 3 12Z" fill="%230073BA"/></svg>');
+      }
+    }
+  }
+}

--- a/src/theme/MDXComponents/Details.module.css
+++ b/src/theme/MDXComponents/Details.module.css
@@ -3,28 +3,31 @@
   box-shadow: unset;
   border-radius: var(--m-1);
   padding: 0;
-  border: none;
-  border-left: 3px solid var(--interactive-accent-link-default);
-  margin-bottom: var(--m-4);
+  border: 1px solid var(--color-tonal-neutral-1);
+  background-color: var(--color-background-depth-2);
+  margin-bottom: var(--m-1);
 
   summary {
-    margin-left: 56px;
     display: flex;
     align-items: center;
     position: relative;
-    padding: var(--m-1-5) var(--m-2) var(--m-1-5) 0;
+    padding: var(--m-1-5) var(--m-2) var(--m-1-5) 56px;
+    background-color: var(--color-background-depth-3);
+    border-bottom: unset;
     font-weight: var(--fw-bold);
+    border-radius: var(--m-1) var(--m-1) 0 0;
     &::before {
       width: 24px;
       height: 24px;
       margin-right: var(--m-1-5);
       border: unset;
-      left: -12px;
+      left: var(--m-2);
       top: 50%;
-      transform: translate(-100%, -50%) !important;
+      transform: translateY(-50%) !important;
       background-repeat: no-repeat;
+      background-position: center;
       transition: background-image var(--t-fast) ease-in-out;
-      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12.75 3.75C12.75 3.33579 12.4142 3 12 3C11.5858 3 11.25 3.33579 11.25 3.75V11.25H3.75C3.33579 11.25 3 11.5858 3 12C3 12.4142 3.33579 12.75 3.75 12.75H11.25V20.25C11.25 20.6642 11.5858 21 12 21C12.4142 21 12.75 20.6642 12.75 20.25V12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H12.75V3.75Z" fill="%230073BA"/></svg>');
+      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6.5 0.5C6.5 0.223858 6.27614 0 6 0C5.72386 0 5.5 0.223858 5.5 0.5V5.5H0.5C0.223858 5.5 0 5.72386 0 6C0 6.27614 0.223858 6.5 0.5 6.5H5.5V11.5C5.5 11.7761 5.72386 12 6 12C6.27614 12 6.5 11.7761 6.5 11.5V6.5H11.5C11.7761 6.5 12 6.27614 12 6C12 5.72386 11.7761 5.5 11.5 5.5H6.5V0.5Z" fill="black" fill-opacity="0.54"/></svg>');
     }
   }
 
@@ -32,17 +35,19 @@
     & > div {
       margin: 0;
       padding: var(--m-2);
-      border-top-color: var(--color-interactive-tonal-accent-informational-2);
+      border-top: 1px solid var(--color-tonal-neutral-1);
     }
   }
 
   &[data-collapsed="false"] {
     summary {
       &::before {
-        background-repeat: no-repeat;
-        background-position: center;
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 12C3 11.5858 3.33579 11.25 3.75 11.25H20.25C20.6642 11.25 21 11.5858 21 12C21 12.4142 20.6642 12.75 20.25 12.75H3.75C3.33579 12.75 3 12.4142 3 12Z" fill="%230073BA"/></svg>');
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 8C2 7.72386 2.22386 7.5 2.5 7.5H13.5C13.7761 7.5 14 7.72386 14 8C14 8.27614 13.7761 8.5 13.5 8.5H2.5C2.22386 8.5 2 8.27614 2 8Z" fill="black" fill-opacity="0.54"/></svg>');
       }
     }
+  }
+
+  a {
+    color: var(--color-dark-purple);
   }
 }

--- a/src/theme/MDXComponents/Details.tsx
+++ b/src/theme/MDXComponents/Details.tsx
@@ -2,6 +2,7 @@ import React, { type ReactNode } from "react";
 import Details from "@theme-original/MDXComponents/Details";
 import type DetailsType from "@theme/MDXComponents/Details";
 import type { WrapperProps } from "@docusaurus/types";
+import cn from "classnames";
 import styles from "./Details.module.css";
 
 type Props = WrapperProps<typeof DetailsType>;
@@ -9,7 +10,10 @@ type Props = WrapperProps<typeof DetailsType>;
 export default function DetailsWrapper(props: Props): ReactNode {
   return (
     <>
-      <Details {...props} className={styles.details} />
+      <Details
+        {...props}
+        className={cn(styles.details, { [styles.neutral]: !!props?.neutral })}
+      />
     </>
   );
 }

--- a/src/theme/MDXComponents/Details.tsx
+++ b/src/theme/MDXComponents/Details.tsx
@@ -1,26 +1,15 @@
-import React, {
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react";
-import Details from "@theme/Details";
-import type { Props } from "@theme/MDXComponents/Details";
+import React, { type ReactNode } from "react";
+import Details from "@theme-original/MDXComponents/Details";
+import type DetailsType from "@theme/MDXComponents/Details";
+import type { WrapperProps } from "@docusaurus/types";
 import styles from "./Details.module.css";
 
-export default function MDXDetails(props: Props): ReactNode {
-  const items = React.Children.toArray(props.children);
-  // Split summary item from the rest to pass it as a separate prop to the
-  // Details theme component
+type Props = WrapperProps<typeof DetailsType>;
 
-  const summary = items.find(
-    (item): item is ReactElement<ComponentProps<"summary">> =>
-      React.isValidElement(item) && item.type === "summary"
-  );
-  const children = <>{items.filter((item) => item !== summary)}</>;
-
+export default function DetailsWrapper(props: Props): ReactNode {
   return (
-    <Details {...props} summary={summary} className={styles.details}>
-      {children}
-    </Details>
+    <>
+      <Details {...props} className={styles.details} />
+    </>
   );
 }

--- a/src/theme/MDXComponents/Details.tsx
+++ b/src/theme/MDXComponents/Details.tsx
@@ -1,0 +1,26 @@
+import React, {
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import Details from "@theme/Details";
+import type { Props } from "@theme/MDXComponents/Details";
+import styles from "./Details.module.css";
+
+export default function MDXDetails(props: Props): ReactNode {
+  const items = React.Children.toArray(props.children);
+  // Split summary item from the rest to pass it as a separate prop to the
+  // Details theme component
+
+  const summary = items.find(
+    (item): item is ReactElement<ComponentProps<"summary">> =>
+      React.isValidElement(item) && item.type === "summary"
+  );
+  const children = <>{items.filter((item) => item !== summary)}</>;
+
+  return (
+    <Details {...props} summary={summary} className={styles.details}>
+      {children}
+    </Details>
+  );
+}


### PR DESCRIPTION
This PR adjusts styles for selected components based on the [Figma design](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=7111-65370) of the FAQ page, and the design of the [Configure Single Sign-On](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=5463-47897) page.

Changes:
- Adjust the `<Tabs>` component styles
- Adjust the `<details>` component styles and add a `neutral` variant for it in order to change the appearance.
- Add CSS variables based on the styles used in the design.

Previews:
- FAQ page with the `neutral` style variant of the `<details>`: https://aatuvai-2026-01-22-faq-page.d2mrezcly5gcqm.amplifyapp.com/docs/faq/
- Another page with the default `<details>` styling: https://aatuvai-2026-01-22-faq-page.d2mrezcly5gcqm.amplifyapp.com/docs/connect-your-client/model-context-protocol/mcp-access/