### PR TITLE
Move deprecated siteConfig.onBrokenMarkdownLinks option under `markdown`

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -163,10 +163,12 @@ const config: Config = {
 
       return result;
     },
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
   },
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   i18n: {
     defaultLocale: "en",
     locales: ["en"],


### PR DESCRIPTION
This PR makes a minor configuration update to the Docusaurus site. The change moves the `onBrokenMarkdownLinks: "throw"` setting into the `hooks` section of the `config` object.

The change fixes the following warning raised during Docusaurus builds:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

Changes:
  * Moved the deprecated `onBrokenMarkdownLinks: "throw"` setting from the root of the config to the `hooks` section in `docusaurus.config.ts`