### PR TITLE
DocHero: set media container `object-fit` value to `contain`

### DIFF
--- a/src/components/Pages/Landing/DocHero/DocHero.module.css
+++ b/src/components/Pages/Landing/DocHero/DocHero.module.css
@@ -151,7 +151,7 @@
 
   .image,
   .video {
-    object-fit: cover;
+    object-fit: contain;
     aspect-ratio: 600/337.5;
     border-radius: 12px;
     width: 100%;


### PR DESCRIPTION
This PR changes the `object-fit` value of the media container to `contain` in order to prevent an issue where the image overflows the container.