### PR TITLE
Agentic Identity Framework page adjustments

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
     },
     {
       "name": "18.x",
-      "branch": "branch/v18",
+      "repo_path": "aatuvai/teleport",
+      "branch": "aatuvai/agentic-ai-updates",
       "isDefault": true
     },
     {

--- a/config.json
+++ b/config.json
@@ -6,8 +6,7 @@
     },
     {
       "name": "18.x",
-      "repo_path": "aatuvai/teleport",
-      "branch": "aatuvai/agentic-ai-updates",
+      "branch": "branch/v18",
       "isDefault": true
     },
     {

--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -1,0 +1,15 @@
+.callout {
+  display: flex;
+  padding: var(--m-2) var(--m-4);
+  align-items: center;
+  gap: 10px;
+  align-self: stretch;
+  border-radius: var(--m-1);
+  border-left: var(--m-0-5) solid var(--color-dark-purple);
+  background: var(--color-background-depth-2);
+  font-size: var(--fs-text-xl);
+  font-weight: var(--fw-bold);
+  font-style: italic;
+  line-height: 1.333;
+  margin: var(--m-2) 0 var(--m-3) 0;
+}

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,0 +1,9 @@
+import styles from "./Callout.module.css";
+
+const Callout: React.FC<{
+  text: string;
+}> = ({ text }) => {
+  return <div className={styles.callout}>{text}</div>;
+};
+
+export default Callout;

--- a/src/components/Callout/index.ts
+++ b/src/components/Callout/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Callout";

--- a/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
+++ b/src/components/Pages/Homepage/GetStarted/GetStarted.module.css
@@ -11,7 +11,9 @@
 
   @media (max-width: 576px) {
     font-size: 1.5rem;
-    margin-bottom: calc(var(--ifm-heading-vertical-rhythm-bottom) * var(--ifm-leading));
+    margin-bottom: calc(
+      var(--ifm-heading-vertical-rhythm-bottom) * var(--ifm-leading)
+    );
   }
 }
 
@@ -55,7 +57,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: var(--lp-box-shadow-hover);
+      box-shadow: var(--lp-box-shadow);
     }
   }
 
@@ -109,7 +111,7 @@
     &:hover {
       cursor: pointer;
       background: var(--color-white);
-      box-shadow: var(--lp-box-shadow-hover);
+      box-shadow: var(--lp-box-shadow);
       .linkTitle {
         color: var(--color-dark-purple);
       }

--- a/src/components/Pages/Homepage/Integrations/Integrations.module.css
+++ b/src/components/Pages/Homepage/Integrations/Integrations.module.css
@@ -167,7 +167,7 @@
 
   &:hover {
     background: var(--color-white);
-    box-shadow: var(--lp-box-shadow-hover);
+    box-shadow: var(--lp-box-shadow);
     border-color: rgba(0, 0, 0, 0);
   }
 }

--- a/src/components/Pages/Landing/EnrollmentMethods/EnrollmentMethods.module.css
+++ b/src/components/Pages/Landing/EnrollmentMethods/EnrollmentMethods.module.css
@@ -60,6 +60,10 @@
   &.withDescription {
     margin-bottom: var(--m-0-5);
   }
+
+  &.md {
+    font-size: var(--fs-header-3);
+  }
 }
 
 .description {

--- a/src/components/Pages/Landing/EnrollmentMethods/EnrollmentMethods.tsx
+++ b/src/components/Pages/Landing/EnrollmentMethods/EnrollmentMethods.tsx
@@ -33,6 +33,8 @@ interface EnrollmentMethod {
 
 interface EnrollmentMethodsProps {
   title?: string;
+  titleType?: "h2" | "h3"; // default is h2
+  titleSize?: "md" | "lg"; // 24px or 32px, lg by default
   description?: string;
   children?: React.ReactNode;
   variant?: "default" | "rows";
@@ -218,6 +220,8 @@ export const Method: React.FC<EnrollmentMethod> = ({
 
 const EnrollmentMethods: React.FC<EnrollmentMethodsProps> = ({
   title,
+  titleType = "h2",
+  titleSize = "lg",
   description,
   children,
   variant = "default",
@@ -227,19 +231,21 @@ const EnrollmentMethods: React.FC<EnrollmentMethodsProps> = ({
   linkColor = "black",
   fontSize = "lg",
 }) => {
+  const TitleTag = titleType === "h2" || titleType === "h3" ? titleType : "h2";
   return (
     <section className={styles.enrollmentMethods}>
       <div className={styles.container}>
         {title && (
           <div className={styles.header}>
-            <h2
+            <TitleTag
               className={cn(styles.title, {
                 [styles.rowsVariant]: variant === "rows",
                 [styles.withDescription]: description,
+                [styles[titleSize]]: titleSize,
               })}
             >
               {title}
-            </h2>
+            </TitleTag>
             {description && <p className={styles.description}>{description}</p>}
           </div>
         )}

--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -206,6 +206,14 @@
     margin-top: var(--m-5);
     font-size: var(--fs-header-3);
   }
+
+  &.lg {
+    font-size: var(--fs-header-3);
+
+    @media (--md-scr) {
+      font-size: var(--fs-header-1);
+    }
+  }
 }
 
 .links {

--- a/src/components/Pages/Landing/LandingHero/LandingHero.module.css
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.module.css
@@ -276,7 +276,7 @@
     .linkDescription {
       font-size: 15.95px;
       margin-bottom: unset;
-      color: var(--color-black);
+      color: var(--color-foreground-slightly-muted);
       line-height: 1.625;
     }
 

--- a/src/components/Pages/Landing/LandingHero/LandingHero.tsx
+++ b/src/components/Pages/Landing/LandingHero/LandingHero.tsx
@@ -20,6 +20,8 @@ interface LandingHeroProps {
   image?: any;
   youtubeVideoId?: string;
   linksTitle?: string;
+  linksTitleSize?: "md" | "lg"; // 24px or 32px, default is md
+  linksDescription?: any;
   linksColumnCount?: number;
   links?: GetStartedLink[];
   emitEvent?: (name: string, params: any) => {};
@@ -32,6 +34,8 @@ const LandingHero: React.FC<LandingHeroProps> = ({
   image,
   youtubeVideoId,
   linksTitle,
+  linksTitleSize = "md",
+  linksDescription,
   linksColumnCount = 2,
   links = [],
   emitEvent,
@@ -93,8 +97,11 @@ const LandingHero: React.FC<LandingHeroProps> = ({
           </div>
         </div>
         {linksTitle && links.length > 0 && (
-          <h2 className={styles.linksTitle}>{linksTitle}</h2>
+          <h2 className={cn(styles.linksTitle, styles[linksTitleSize || "md"])}>
+            {linksTitle}
+          </h2>
         )}
+        {linksDescription && <>{linksDescription}</>}
         {links.length > 0 && (
           <div
             className={styles.links}
@@ -121,7 +128,7 @@ const LandingHero: React.FC<LandingHeroProps> = ({
                     <link.icon className={styles.linkIcon} />
                   </div>
                 </div>
-              )
+              ),
             )}
           </div>
         )}

--- a/src/theme/DocRoot/Layout/Main/styles.module.css
+++ b/src/theme/DocRoot/Layout/Main/styles.module.css
@@ -12,10 +12,18 @@
   width: 100%;
 }
 
-:global(main.template-full-width) :global(.container) :global(.theme-doc-markdown) {
+:global(main.template-full-width)
+  :global(.container)
+  :global(.theme-doc-markdown) {
   > :global(:not(section)) {
     max-width: var(--lp-section-max-width);
     margin-left: auto;
     margin-right: auto;
   }
+}
+
+:global(main.template-full-width) :global(.container) :global(.pagination-nav) {
+  max-width: var(--lp-section-max-width);
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -28,6 +28,7 @@ import EnterpriseFeatureCallout from "/src/components/EnterpriseFeatureCallout";
 import { ChangelogLink } from "/src/components/ChangelogLink";
 import InlineCTA from "/src/components/InlineCTA/InlineCTA";
 import EnterpriseFeatureWidget from "@site/src/components/EnterpriseFeatureWidget/EnterpriseFeatureWidget";
+import Callout from "@site/src/components/Callout";
 
 const MDXComponents: MDXComponentsObject = {
   ...OriginalMDXComponents,
@@ -67,6 +68,7 @@ const MDXComponents: MDXComponentsObject = {
   EnterpriseFeatureCallout,
   EnterpriseFeatureWidget,
   InlineCTA,
+  Callout,
 };
 
 export default MDXComponents;


### PR DESCRIPTION
This PR adjusts the Agentic Identity Framework landing page according to the updated [Figma design](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=9034-49136).

Changes:
- Add the `Callout` component to display the callout component shown in the design.
- Adjust the `LandingHero` component:
  - Add two new configuration properties to control what's displayed with the optional `links` (title size and description text)
- Adjust the `EnrollmentMethods` component:
  - Allow changing the title tag between `h2` and h3`. Also, allow changing the size of the title.