### PR TITLE
LLMs features: cleaner markdown page output, adjust `PageActions` responsiveness

### DIFF
--- a/server/fixtures/llms/images.html
+++ b/server/fixtures/llms/images.html
@@ -1,0 +1,2 @@
+<p>Paragraph before image.</p><img src="/img/logo.png" alt="Logo">
+<p>Paragraph after image.</p><img src="/img/diagram.svg" alt="Diagram" class="diagram_abc">

--- a/server/fixtures/llms/result/images.html
+++ b/server/fixtures/llms/result/images.html
@@ -1,0 +1,2 @@
+<p>Paragraph before image.</p>
+<p>Paragraph after image.</p>

--- a/server/llms/rehype-prepare-html.test.ts
+++ b/server/llms/rehype-prepare-html.test.ts
@@ -146,6 +146,19 @@ describe("server/llms/rehype-prepare-html", () => {
     );
   });
 
+  test("Images: removes all img elements, preserving surrounding content", () => {
+    const result = transformer(
+      readFileSync(resolve("server/fixtures/llms/images.html"), "utf-8"),
+    );
+
+    expect((result.value as string).trim()).toBe(
+      readFileSync(
+        resolve("server/fixtures/llms/result/images.html"),
+        "utf-8",
+      ).trim(),
+    );
+  });
+
   test("Irrelevant components: removes thumbsFeedback and checkpoint components, preserving other content", () => {
     const result = transformer(
       readFileSync(

--- a/server/llms/rehype-prepare-html.ts
+++ b/server/llms/rehype-prepare-html.ts
@@ -11,6 +11,7 @@ import { visitParents, SKIP } from "unist-util-visit-parents";
  * Code blocks: extract text content and replace with clean <pre><code> structure
  * Card links: prevent duplicate links in the markdown output
  * Heading anchor links: remove hash-link anchors from headings
+ * Images: remove all image elements from the output
  * Irrelevant components: remove interactive UI components (thumbsFeedback, checkpoint, docsHeader)
  * H1 repositioning: move the h1 heading to the top of the document
  */
@@ -84,6 +85,12 @@ const rehypePrepareHTML: Plugin<[], Root, Root> = function () {
       ) {
         toRemove.push({ node: element, parent });
         return SKIP; // don't traverse children (e.g. avoids capturing an h1 inside a removed node)
+      }
+
+      // *** Images ***
+      if (element.tagName === "img") {
+        toRemove.push({ node: element, parent });
+        return SKIP;
       }
 
       // *** Headings ***

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,6 +7,7 @@ import type {
 import { clsx } from "clsx";
 
 import styles from "./Button.module.css";
+import Link from "@docusaurus/Link";
 
 export type ButtonVariant =
   | "primary"
@@ -55,7 +56,7 @@ const Button = ({
   };
 
   if (as === "link") {
-    return <a {...(props as DefaultAnchorProps)} />;
+    return <Link {...(props as DefaultAnchorProps)} />;
   }
 
   return <button {...(props as DefaultButtonProps)} />;

--- a/src/components/PageActions/PageActions.module.css
+++ b/src/components/PageActions/PageActions.module.css
@@ -1,6 +1,6 @@
 .pageActions {
   display: flex;
-  gap: var(--m-3);
+  gap: var(--m-2);
   padding: var(--m-1-5) 0;
   border-bottom: 1px solid var(--color-tonal-neutral-2);
   margin-bottom: var(--m-5);
@@ -10,7 +10,7 @@
       &::after {
         content: "";
         position: relative;
-        transform: translateX(var(--m-1-5));
+        transform: translateX(var(--m-1));
         width: 1px;
         height: 100%;
         background-color: var(--color-tonal-neutral-1);
@@ -18,7 +18,19 @@
     }
   }
 
-  @media (--lg-scr) {
+  @media (--md-scr) {
+    gap: var(--m-3);
+
+    & > * {
+      &:not(:nth-last-child(2)) {
+        &::after {
+          transform: translateX(var(--m-1-5));
+        }
+      }
+    }
+  }
+
+  @media (--desktop-page-actions) {
     gap: var(--m-4);
     margin-bottom: var(--m-6);
     & > * {
@@ -53,7 +65,8 @@
   color: var(--color-foreground-slightly-muted);
   display: flex;
   align-items: center;
-  font-size: var(--fs-text-lg);
+  font-size: var(--fs-text-sm);
+  white-space: nowrap;
   letter-spacing: 0.024px;
   line-height: 1.625;
   margin: 0;
@@ -61,11 +74,11 @@
   font-weight: var(--fw-medium);
 
   & > svg {
-    width: 20px;
-    height: 20px;
-    min-width: 20px;
-    min-height: 20px;
-    margin-right: var(--m-0-5);
+    width: var(--m-2);
+    height: var(--m-2);
+    min-width: var(--m-2);
+    min-height: var(--m-2);
+    margin-right: 2px;
     & > path {
       fill: var(--color-foreground-muted);
     }
@@ -74,10 +87,24 @@
   @media (--xs-scr) {
     width: auto;
     height: auto;
+    font-size: var(--fs-text-md);
+
+    & > svg {
+      margin-right: var(--m-0-5);
+    }
   }
 
   @media (--md-scr) {
     line-height: 1.75;
+    font-size: var(--fs-text-lg);
+
+    & > svg {
+      width: 20px;
+      height: 20px;
+      min-width: 20px;
+      min-height: 20px;
+      margin-right: var(--m-0-5);
+    }
   }
 }
 

--- a/src/components/PageActions/PageActions.module.css
+++ b/src/components/PageActions/PageActions.module.css
@@ -46,6 +46,18 @@
       }
     }
   }
+
+  &.pageHasTOC {
+    @media screen and (min-width: 997px) and (max-width: 1301px) {
+      & > * {
+        &:not(:last-child) {
+          &::after {
+            display: none;
+          }
+        }
+      }
+    }
+  }
 }
 
 .askAIButton {

--- a/src/components/PageActions/PageActions.module.css
+++ b/src/components/PageActions/PageActions.module.css
@@ -56,6 +56,11 @@
           }
         }
       }
+      .githubLink,
+      .askAIButton,
+      .feedback {
+        white-space: wrap;
+      }
     }
   }
 }

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -1,4 +1,5 @@
 import { getReportIssueURL } from "@site/src/utils/github-issue";
+import cn from "clsx";
 import styles from "./PageActions.module.css";
 import Icon from "../Icon";
 import { useInkeepSearch } from "@site/src/hooks/useInkeepSearch";
@@ -11,7 +12,10 @@ import {
 import { useMemo, useRef, useState } from "react";
 import { useWindowSize } from "@docusaurus/theme-common";
 
-const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
+const PageActions: React.FC<{ pathname: string; pageHasTOC: boolean }> = ({
+  pathname,
+  pageHasTOC,
+}) => {
   const { setIsOpen, ModalSearchAndChat, inkeepModalProps } = useInkeepSearch({
     enableAIChat: true,
   });
@@ -26,7 +30,9 @@ const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
   );
 
   return (
-    <div className={styles.pageActions}>
+    <div
+      className={cn(styles.pageActions, { [styles.pageHasTOC]: pageHasTOC })}
+    >
       <a
         className={styles.githubLink}
         href={getReportIssueURL(pathname)}
@@ -58,7 +64,7 @@ const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
         <Icon size="md" name="markdown" />
         <span>View as Markdown</span>
       </a>
-      <ThumbsFeedback />
+      <ThumbsFeedback pageHasTOC={pageHasTOC} />
       <BrowserOnly fallback={<div />}>
         {() => {
           return (

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -68,7 +68,8 @@ const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
         <Icon size="md" name="markdown" />
         <span>View as Markdown</span>
       </a>
-      <ThumbsFeedback />
+      {/* docTOC.canRender is passed to ThumbsFeedback instead of calling directly in the child, because the component is rendered in different places and contexts */}
+      <ThumbsFeedback pageHasTOC={docTOC.canRender} />
       <BrowserOnly fallback={<div />}>
         {() => {
           return (

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -11,15 +11,17 @@ import {
 } from "@site/src/utils/markdown";
 import { useMemo, useRef, useState } from "react";
 import { useWindowSize } from "@docusaurus/theme-common";
+import { useDocTOC } from "@site/src/theme/DocItem/Layout";
+import { useDocTemplate } from "@site/src/hooks/useDocTemplate";
 
-const PageActions: React.FC<{ pathname: string; pageHasTOC: boolean }> = ({
-  pathname,
-  pageHasTOC,
-}) => {
+const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
   const { setIsOpen, ModalSearchAndChat, inkeepModalProps } = useInkeepSearch({
     enableAIChat: true,
   });
+  const { removeTOCSidebar } = useDocTemplate();
   const windowSize = useWindowSize();
+  const docTOC = useDocTOC(!!removeTOCSidebar);
+
   const [copiedMessage, setCopiedMessage] = useState<string>("Copy for LLM");
 
   const copyButtonRef = useRef<HTMLButtonElement>(null);
@@ -31,7 +33,9 @@ const PageActions: React.FC<{ pathname: string; pageHasTOC: boolean }> = ({
 
   return (
     <div
-      className={cn(styles.pageActions, { [styles.pageHasTOC]: pageHasTOC })}
+      className={cn(styles.pageActions, {
+        [styles.pageHasTOC]: docTOC.canRender,
+      })}
     >
       <a
         className={styles.githubLink}
@@ -64,7 +68,7 @@ const PageActions: React.FC<{ pathname: string; pageHasTOC: boolean }> = ({
         <Icon size="md" name="markdown" />
         <span>View as Markdown</span>
       </a>
-      <ThumbsFeedback pageHasTOC={pageHasTOC} />
+      <ThumbsFeedback />
       <BrowserOnly fallback={<div />}>
         {() => {
           return (

--- a/src/components/ThumbsFeedback/ThumbsFeedback.module.css
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.module.css
@@ -3,7 +3,7 @@
     display: none;
   }
 
-  @media (--lg-scr) {
+  @media (--desktop-page-actions) {
     display: block !important;
   }
 
@@ -83,7 +83,7 @@
     color: var(--color-foreground-slightly-muted);
     align-items: center;
     gap: var(--m-1);
-    font-size: var(--fs-text-lg);
+    font-size: var(--fs-text-md);
     letter-spacing: 0.024px;
     line-height: 1.625;
     margin: 0;
@@ -92,6 +92,7 @@
 
     @media (--md-scr) {
       line-height: 1.75;
+      font-size: var(--fs-text-lg);
     }
 
     & > svg {

--- a/src/components/ThumbsFeedback/ThumbsFeedback.module.css
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.module.css
@@ -7,6 +7,12 @@
     display: block !important;
   }
 
+  &.pageHasTOC {
+    @media screen and (min-width: 997px) and (max-width: 1301px) {
+      display: none !important;
+    }
+  }
+
   .feedbackTitle {
     font-size: var(--fs-text-sm);
     line-height: var(--lh-md);

--- a/src/components/ThumbsFeedback/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.tsx
@@ -19,6 +19,8 @@ import Icon from "../Icon/Icon";
 import ThumbsFeedbackContext from "./context";
 import styles from "./ThumbsFeedback.module.css";
 import { FeedbackType, StoredFeedback } from "./types";
+import { useDocTemplate } from "@site/src/hooks/useDocTemplate";
+import { useDocTOC } from "@site/src/theme/DocItem/Layout";
 
 const MAX_PATHS_IN_STORAGE = 4;
 
@@ -246,17 +248,19 @@ const FeedbackForm: React.FC<{
 const ThumbsFeedback: React.FC<{
   feedbackLabel?: string;
   pagePosition?: "top" | "bottom";
-  pageHasTOC?: boolean;
   emitEvent?: (name: string, params: any) => {};
 }> = ({
   feedbackLabel = "Is this page helpful?",
   pagePosition = "top",
-  pageHasTOC = false,
   emitEvent,
 }): JSX.Element => {
   const { feedback, isSubmitted, setFeedback, setIsSubmitted } = useContext(
     ThumbsFeedbackContext,
   );
+
+  const { removeTOCSidebar } = useDocTemplate();
+  const docTOC = useDocTOC(!!removeTOCSidebar);
+
   const [comment, setComment] = useState<string>("");
   const [formActive, setFormActive] = useState<"positive" | "negative" | false>(
     false,
@@ -351,7 +355,7 @@ const ThumbsFeedback: React.FC<{
     <div
       className={cn(styles.thumbsFeedback, {
         [styles.positionBottom]: pagePosition === "bottom",
-        [styles.pageHasTOC]: pageHasTOC,
+        [styles.pageHasTOC]: docTOC.canRender,
       })}
     >
       <div

--- a/src/components/ThumbsFeedback/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.tsx
@@ -19,8 +19,6 @@ import Icon from "../Icon/Icon";
 import ThumbsFeedbackContext from "./context";
 import styles from "./ThumbsFeedback.module.css";
 import { FeedbackType, StoredFeedback } from "./types";
-import { useDocTemplate } from "@site/src/hooks/useDocTemplate";
-import { useDocTOC } from "@site/src/theme/DocItem/Layout";
 
 const MAX_PATHS_IN_STORAGE = 4;
 
@@ -248,19 +246,17 @@ const FeedbackForm: React.FC<{
 const ThumbsFeedback: React.FC<{
   feedbackLabel?: string;
   pagePosition?: "top" | "bottom";
+  pageHasTOC?: boolean;
   emitEvent?: (name: string, params: any) => {};
 }> = ({
   feedbackLabel = "Is this page helpful?",
   pagePosition = "top",
+  pageHasTOC = false,
   emitEvent,
 }): JSX.Element => {
   const { feedback, isSubmitted, setFeedback, setIsSubmitted } = useContext(
     ThumbsFeedbackContext,
   );
-
-  const { removeTOCSidebar } = useDocTemplate();
-  const docTOC = useDocTOC(!!removeTOCSidebar);
-
   const [comment, setComment] = useState<string>("");
   const [formActive, setFormActive] = useState<"positive" | "negative" | false>(
     false,
@@ -355,7 +351,7 @@ const ThumbsFeedback: React.FC<{
     <div
       className={cn(styles.thumbsFeedback, {
         [styles.positionBottom]: pagePosition === "bottom",
-        [styles.pageHasTOC]: docTOC.canRender,
+        [styles.pageHasTOC]: pageHasTOC,
       })}
     >
       <div

--- a/src/components/ThumbsFeedback/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback/ThumbsFeedback.tsx
@@ -24,7 +24,7 @@ const MAX_PATHS_IN_STORAGE = 4;
 
 const checkForExpiredFeedback = (
   itemStr: string,
-  currentPath: string
+  currentPath: string,
 ): StoredFeedback[] => {
   let feedbackGivenPaths: StoredFeedback[] = [];
   try {
@@ -38,17 +38,17 @@ const checkForExpiredFeedback = (
     const now = new Date();
 
     const foundCurrentPath = feedbackGivenPaths.find(
-      (pathItem) => pathItem.path === currentPath
+      (pathItem) => pathItem.path === currentPath,
     );
 
     if (foundCurrentPath && now.getTime() > foundCurrentPath.expiry) {
       // Remove expired path and update storage
       feedbackGivenPaths = feedbackGivenPaths.filter(
-        (pathItem) => pathItem.path !== currentPath
+        (pathItem) => pathItem.path !== currentPath,
       );
       localStorage.setItem(
         "feedback_given_paths",
-        JSON.stringify(feedbackGivenPaths)
+        JSON.stringify(feedbackGivenPaths),
       );
     }
   } catch (e) {
@@ -134,7 +134,7 @@ const FeedbackForm: React.FC<{
   }, [formActive]);
 
   const handleSubmit = async (
-    event: FormEvent<HTMLFormElement>
+    event: FormEvent<HTMLFormElement>,
   ): Promise<void> => {
     event.preventDefault();
 
@@ -149,11 +149,11 @@ const FeedbackForm: React.FC<{
 
       let feedbackGivenPaths: StoredFeedback[] = checkForExpiredFeedback(
         localStorage.getItem("feedback_given_paths"),
-        currentPath
+        currentPath,
       );
 
       const foundCurrentPath = feedbackGivenPaths.find(
-        (pathItem) => pathItem.path === currentPath
+        (pathItem) => pathItem.path === currentPath,
       );
 
       if (foundCurrentPath?.commented && isSubmitted) {
@@ -171,7 +171,7 @@ const FeedbackForm: React.FC<{
         });
         localStorage.setItem(
           "feedback_given_paths",
-          JSON.stringify(feedbackGivenPaths)
+          JSON.stringify(feedbackGivenPaths),
         );
 
         trackEvent({
@@ -185,7 +185,6 @@ const FeedbackForm: React.FC<{
         setIsSubmitted(true);
         return;
       }
-
     }
 
     setIsSubmitted(true);
@@ -247,18 +246,20 @@ const FeedbackForm: React.FC<{
 const ThumbsFeedback: React.FC<{
   feedbackLabel?: string;
   pagePosition?: "top" | "bottom";
+  pageHasTOC?: boolean;
   emitEvent?: (name: string, params: any) => {};
 }> = ({
   feedbackLabel = "Is this page helpful?",
   pagePosition = "top",
+  pageHasTOC = false,
   emitEvent,
 }): JSX.Element => {
   const { feedback, isSubmitted, setFeedback, setIsSubmitted } = useContext(
-    ThumbsFeedbackContext
+    ThumbsFeedbackContext,
   );
   const [comment, setComment] = useState<string>("");
   const [formActive, setFormActive] = useState<"positive" | "negative" | false>(
-    false
+    false,
   );
   const location = useLocation();
 
@@ -272,11 +273,11 @@ const ThumbsFeedback: React.FC<{
     const currentPath = location.pathname;
     const feedbackGivenPaths = checkForExpiredFeedback(
       localStorage.getItem("feedback_given_paths"),
-      currentPath
+      currentPath,
     );
 
     const foundCurrentFeedbackPathClick = feedbackGivenPaths.find(
-      (pathItem) => pathItem.path === currentPath
+      (pathItem) => pathItem.path === currentPath,
     );
 
     const feedbackCommented = foundCurrentFeedbackPathClick?.commented;
@@ -291,14 +292,14 @@ const ThumbsFeedback: React.FC<{
   }, [location.pathname]);
 
   const handleFeedbackClick = async (
-    feedbackValue: FeedbackType
+    feedbackValue: FeedbackType,
   ): Promise<void> => {
     const currentPath = location.pathname;
     const itemStr = localStorage.getItem("feedback_given_paths");
     let clickedPaths = checkForExpiredFeedback(itemStr, currentPath);
 
     const foundCurrentPath = clickedPaths.find(
-      (pathItem) => pathItem.path === currentPath
+      (pathItem) => pathItem.path === currentPath,
     );
 
     if (foundCurrentPath && foundCurrentPath.signal === feedbackValue) {
@@ -307,7 +308,7 @@ const ThumbsFeedback: React.FC<{
       // Remove existing entry for current path to update with new signal
       // Also reset the submission state
       clickedPaths = clickedPaths.filter(
-        (pathItem) => pathItem.path !== currentPath
+        (pathItem) => pathItem.path !== currentPath,
       );
       setIsSubmitted(false);
     }
@@ -336,13 +337,13 @@ const ThumbsFeedback: React.FC<{
     if (newFeedbackThumbsClickedPaths.length > MAX_PATHS_IN_STORAGE) {
       newFeedbackThumbsClickedPaths.splice(
         0,
-        newFeedbackThumbsClickedPaths.length - MAX_PATHS_IN_STORAGE
+        newFeedbackThumbsClickedPaths.length - MAX_PATHS_IN_STORAGE,
       );
     }
 
     localStorage.setItem(
       "feedback_given_paths",
-      JSON.stringify(newFeedbackThumbsClickedPaths)
+      JSON.stringify(newFeedbackThumbsClickedPaths),
     );
   };
 
@@ -350,6 +351,7 @@ const ThumbsFeedback: React.FC<{
     <div
       className={cn(styles.thumbsFeedback, {
         [styles.positionBottom]: pagePosition === "bottom",
+        [styles.pageHasTOC]: pageHasTOC,
       })}
     >
       <div

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -1,6 +1,7 @@
 // Tile.tsx
 import React from "react";
 import styles from "./Tile.module.css";
+import Link from "@docusaurus/Link";
 
 interface TileProps {
   icon: React.ReactNode;
@@ -11,10 +12,10 @@ interface TileProps {
 export default function Tile({ icon, to, name }: TileProps) {
   return (
     <>
-      <a href={to} className={styles.tile}>
+      <Link href={to} className={styles.tile}>
         {icon}
         {name}
-      </a>
+      </Link>
     </>
   );
 }

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -1,4 +1,4 @@
-@custom-media --xs-scr (min-width: 381px);
+@custom-media --xs-scr (min-width: 412px);
 @custom-media --sm-scr (max-width: 900px);
 @custom-media --md-scr (min-width: 901px);
 @custom-media --lg-scr (min-width: 1201px);

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -3,4 +3,5 @@
 @custom-media --md-scr (min-width: 901px);
 @custom-media --lg-scr (min-width: 1201px);
 @custom-media --xl-scr (min-width: 1401px);
-@custom-media --nav (min-width: 997px);
+@custom-media --nav (min-width: 1125px);
+@custom-media --desktop-page-actions (min-width: 696px);

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -3,5 +3,5 @@
 @custom-media --md-scr (min-width: 901px);
 @custom-media --lg-scr (min-width: 1201px);
 @custom-media --xl-scr (min-width: 1401px);
-@custom-media --nav (min-width: 1125px);
+@custom-media --nav (min-width: 997px);
 @custom-media --desktop-page-actions (min-width: 696px);

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -38,7 +38,7 @@ function useSyntheticTitle(): string | null {
 }
   
 
-export default function DocItemContent({ children }: Props): ReactNode {
+export default function DocItemContent({ docTOC, children }: Props): ReactNode {
   const syntheticTitle = useSyntheticTitle();
   const { hideTitleSection, showDescription } = useDocTemplate();
   const { frontMatter } = useDoc();
@@ -63,7 +63,7 @@ export default function DocItemContent({ children }: Props): ReactNode {
             {frontMatter.description && showDescription && (
               <p className="docItemDescription">{frontMatter.description}</p>
             )}
-            <PageActions pathname={location.pathname} />
+            <PageActions pathname={location.pathname} pageHasTOC={!docTOC.removed}/>
             {videoBanner && <VideoBar {...videoBanner} />}
           </header>
         )}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -12,6 +12,7 @@ import Heading from "@theme/Heading";
 import MDXContent from "@theme/MDXContent";
 import clsx from "clsx";
 import { useState, type ReactNode } from "react";
+import { useDocTOC } from "../Layout";
 
 interface DocFrontMatter {
   videoBanner: VideoBarProps;
@@ -38,9 +39,10 @@ function useSyntheticTitle(): string | null {
 }
   
 
-export default function DocItemContent({ docTOC, children }: Props): ReactNode {
+export default function DocItemContent({ children }: Props): ReactNode {
   const syntheticTitle = useSyntheticTitle();
-  const { hideTitleSection, showDescription } = useDocTemplate();
+  const { hideTitleSection, showDescription, removeTOCSidebar } = useDocTemplate();
+    const docTOC = useDocTOC(!!removeTOCSidebar);
   const { frontMatter } = useDoc();
   const location = useLocation();
   const [feedback, setFeedback] = useState<FeedbackType | null>(null);

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -12,7 +12,6 @@ import Heading from "@theme/Heading";
 import MDXContent from "@theme/MDXContent";
 import clsx from "clsx";
 import { useState, type ReactNode } from "react";
-import { useDocTOC } from "../Layout";
 
 interface DocFrontMatter {
   videoBanner: VideoBarProps;
@@ -41,8 +40,7 @@ function useSyntheticTitle(): string | null {
 
 export default function DocItemContent({ children }: Props): ReactNode {
   const syntheticTitle = useSyntheticTitle();
-  const { hideTitleSection, showDescription, removeTOCSidebar } = useDocTemplate();
-    const docTOC = useDocTOC(!!removeTOCSidebar);
+  const { hideTitleSection, showDescription } = useDocTemplate();
   const { frontMatter } = useDoc();
   const location = useLocation();
   const [feedback, setFeedback] = useState<FeedbackType | null>(null);
@@ -65,7 +63,7 @@ export default function DocItemContent({ children }: Props): ReactNode {
             {frontMatter.description && showDescription && (
               <p className="docItemDescription">{frontMatter.description}</p>
             )}
-            <PageActions pathname={location.pathname} pageHasTOC={docTOC.canRender}/>
+            <PageActions pathname={location.pathname} />
             {videoBanner && <VideoBar {...videoBanner} />}
           </header>
         )}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -63,7 +63,7 @@ export default function DocItemContent({ docTOC, children }: Props): ReactNode {
             {frontMatter.description && showDescription && (
               <p className="docItemDescription">{frontMatter.description}</p>
             )}
-            <PageActions pathname={location.pathname} pageHasTOC={!docTOC.removed}/>
+            <PageActions pathname={location.pathname} pageHasTOC={docTOC.canRender}/>
             {videoBanner && <VideoBar {...videoBanner} />}
           </header>
         )}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -45,6 +45,7 @@ function useDocTOC(removeTOCSidebar: boolean) {
   return {
     hidden,
     removed,
+    canRender,
     mobile,
     desktop,
     canRender,

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -95,7 +95,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
                 </div>
               )}
               {docTOC.mobile}
-              <DocItemContent>
+              <DocItemContent docTOC={docTOC}>
                 <PositionProvider>{children}</PositionProvider>
               </DocItemContent>
               <DocItemFooter />

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -25,7 +25,7 @@ interface ExtendedFrontMatter {
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
  */
-function useDocTOC(removeTOCSidebar: boolean) {
+export function useDocTOC(removeTOCSidebar: boolean) {
   const { frontMatter, toc } = useDoc();
   const windowSize = useWindowSize();
 
@@ -63,8 +63,7 @@ function usePageExclusivityBanner() {
 export default function DocItemLayout({ children }: Props): JSX.Element {
   const { hideTitleSection, removeTOCSidebar, fullWidth, isLandingPage } =
     useDocTemplate();
-  const docTOC = useDocTOC(removeTOCSidebar);
-
+  const docTOC = useDocTOC(!!removeTOCSidebar);
   const { exclusiveFeature } = usePageExclusivityBanner();
   const {
     metadata: { unlisted },
@@ -96,7 +95,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
                 </div>
               )}
               {docTOC.mobile}
-              <DocItemContent docTOC={docTOC}>
+              <DocItemContent>
                 <PositionProvider>{children}</PositionProvider>
               </DocItemContent>
               <DocItemFooter />


### PR DESCRIPTION
This PR iterates on the features added to improve docs usage with LLMs.

Markdown page changes:
- Remove images from the markdown pages output.
- Fix broken relative links on a few selected markdown pages by using Docusaurus' `Link` instead of HTML `a` tag in `Tile` and `Button`

Style changes:
- Improve responsiveness for the `PageActions` component by preventing text overflow and adjusting the layout and font size based on screen width