### PR TITLE
Add a background color for enlarged images

### DIFF
--- a/src/theme/MDXComponents/Img/styles.module.css
+++ b/src/theme/MDXComponents/Img/styles.module.css
@@ -33,7 +33,6 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0);
   cursor: zoom-out;
   cursor: -moz-zoom-out;
   cursor: -webkit-zoom-out;
@@ -41,5 +40,8 @@
   & .img {
     max-width: 95vw;
     max-height: 95vh;
+    width: auto;
+    object-fit: contain;
+    background: rgb(255, 255, 255);
   }
 }


### PR DESCRIPTION
This PR adds a white background color for enlarged images. Also, prevents the enlarged image from stretching/squeezing with the screen dimensions.

Resolves #424