### PR TITLE
Use `word-break: normal;` for code elements inside tables

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -122,6 +122,8 @@ svg g.architecture-edges {
   }
 }
 
-table code {
-  word-break: normal !important;
+@media (--md-scr) {
+  table code {
+    word-break: normal !important;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -121,3 +121,7 @@ svg g.architecture-edges {
     fill: var(--color-light-gray) !important;
   }
 }
+
+table code {
+  word-break: normal !important;
+}


### PR DESCRIPTION
This PR prevents `word-break: break-word;` from being applied to `code` elements in tables. It caused issues with code splitting to multiple lines if the column heading was too narrow.

The style is only applied to code inside tables in order to prevent potential unexpected behavior in other spots where the element is used. Additionally, the style is only applied to >900px screen sizes to allow viewing tables without having to scroll horizontally on mobile screens.

Before: https://goteleport.com/docs/connect-your-client/teleport-connect/#configuration
After: https://aatuvai-2026-04-14-table-code-word-break.d2mrezcly5gcqm.amplifyapp.com/docs/connect-your-client/teleport-connect/#configuration

Resolves #113 