### PR TITLE
Conditionally load sub-nav menu items to save on LLM token tax.

### DIFF
--- a/src/components/Menu/Category.tsx
+++ b/src/components/Menu/Category.tsx
@@ -120,9 +120,9 @@ const MenuCategory = ({
             )}
           </span>
         )}
-        {children && (
+        {children && opened && (
           <div
-            className={clsx(styles.dropdown, opened && styles.opened)}
+            className={clsx(styles.dropdown, styles.opened)}
             onMouseLeave={() => toggleOpened(null)}
             data-testid={menuTestId}
           >


### PR DESCRIPTION
This change conditionally renders the upper navigation subnav items to prevent draining LLM token usage.

Related to: https://github.com/gravitational/next/pull/3437

Savings:
```
  ┌───────────────────────────────────┬────────────┬───────────────┬────────┬───────────┬──────────────┬────────┬─────────┐
  │               Page                │ Prod bytes │ Preview bytes │ Saved  │ Prod ~tok │ Preview ~tok │ Δ tok  │ % saved │
  ├───────────────────────────────────┼────────────┼───────────────┼────────┼───────────┼──────────────┼────────┼─────────┤
  │ /docs/ (home)                     │    400,053 │       358,774 │ 41,279 │   100,013 │       89,693 │ 10,320 │   10.3% │
  ├───────────────────────────────────┼────────────┼───────────────┼────────┼───────────┼──────────────┼────────┼─────────┤
  │ /docs/installation/linux/         │    205,502 │       164,223 │ 41,279 │    51,375 │       41,055 │ 10,320 │   20.1% │
  ├───────────────────────────────────┼────────────┼───────────────┼────────┼───────────┼──────────────┼────────┼─────────┤
  │ /docs/agentic-identity-framework/ │    260,104 │       218,825 │ 41,279 │    65,026 │       54,706 │ 10,320 │   15.9% │
  └───────────────────────────────────┴────────────┴───────────────┴────────┴───────────┴──────────────┴────────┴─────────┘
```

