### PR TITLE
Fix remarkIncludes

### DIFF
--- a/server/remark-includes.test.ts
+++ b/server/remark-includes.test.ts
@@ -595,6 +595,17 @@ boundary" section.
 [definition]: ../installation.mdx
 `,
       },
+      {
+        includingPage: `(!include-relative-link.mdx foo="b/a/r"!)`,
+        description: "including files with a param",
+        path: "server/fixtures/dir/samelevel.mdx",
+        expected: `Check out our [instructions](../installation.mdx).
+
+Here is an image showing a successful installation:
+
+[Successful installation](../installation.png)
+`,
+      },
     ];
 
     test.each(testCases)("$description", (testCase) => {

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -375,12 +375,13 @@ export default function remarkIncludes({
                 rootDir: resolvedRootDir,
               });
 
-              const path = txt.value.match(exactIncludeRegexp)[1];
+              const includeExpr = txt.value.match(exactIncludeRegexp)[1];
+              const path = includeExpr.split(" ")[0];
 
               // Parse the partial as a Markdown AST and insert it into the
               // parent AST.
               if (resolve) {
-                if (path.split(" ")[0].match(/\.mdx?$/)) {
+                if (path.match(/\.mdx?$/)) {
                   const tree = fromMarkdown(result, {
                     extensions: [mdxjs(), gfm(), frontmatter()],
                     mdastExtensions: [


### PR DESCRIPTION
Currently, if we include a partial that has a parameter that contains a slash, this slash gets interpreted as a part of the relative paths to be replaced, causing very confusing errors. This PR fixes it by using the same path for matching as well as replacing.