### PR TITLE
Clarify error message if conflicting sidebar item is a category type

### DIFF
--- a/server/sidebar-order.test.ts
+++ b/server/sidebar-order.test.ts
@@ -1133,6 +1133,57 @@ describe("orderSidebarItems", () => {
     );
   });
 
+  test("identical sidebar position with a 'category' type sidebar item", () => {
+    const idToDocPage = {
+      "section-b/section-b": {
+        title: "Section B",
+        id: "section-b/section-b",
+        frontMatter: {
+          title: "Section B",
+          description: "Section B",
+        },
+        source: "@site/docs/section-b/section-b.mdx",
+        sourceDirName: "section-b",
+        sidebarPosition: 2,
+      },
+      "page-a": {
+        title: "Page A",
+        id: "page-a",
+        frontMatter: {
+          title: "Page A",
+          description: "Page A",
+        },
+        source: "@site/docs/page-a.mdx",
+        sourceDirName: "",
+        sidebarPosition: 2,
+      },
+    };
+
+    const input: Array<NormalizedSidebarItem> = [
+      {
+        type: "category",
+        label: "Section B",
+        link: {
+          type: "doc",
+          id: "section-b/section-b",
+        },
+        items: [],
+      },
+      {
+        type: "doc",
+        id: "page-a",
+      },
+    ];
+
+    expect(() => {
+      orderSidebarItems(input, (id: string): docPage => {
+        return idToDocPage[id];
+      });
+    }).toThrow(
+      "page with ID page-a has the same sidebar_position frontmatter value as the page with ID section-b/section-b in the same sidebar section",
+    );
+  });
+
   test("sidebar position out of bounds", () => {
     const idToDocPage = {
       "page-a": {

--- a/server/sidebar-order.ts
+++ b/server/sidebar-order.ts
@@ -99,8 +99,9 @@ export const orderSidebarItems = (
     const sideBarIndex = sidebarPosition - 1;
 
     if (newItems[sideBarIndex]) {
+      const conflictingPageId = getOrderAttributes(newItems[sideBarIndex], getter)?.id ?? "[unknown]";
       throw new Error(
-        `page with ID ${id} has the same sidebar_position frontmatter value as the page with ID ${newItems[sideBarIndex].id} in the same sidebar section`,
+        `page with ID ${id} has the same sidebar_position frontmatter value as the page with ID ${conflictingPageId} in the same sidebar section`,
       );
     }
     newItems[sideBarIndex] = newItem;


### PR DESCRIPTION
This PR clarifies the error message thrown when a page with a conflicting `sidebar_position` frontmatter value is detected.

Previously the ID of the conflicting page could have been `undefined` if the `newItems[sidebarIndex]` had the `category` type.

`"[unknown]"` is returned as a fallback.