### PR TITLE
Remove the `docs` directory in prepare-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ versioned_docs/*
 versioned_sidebars/*
 !versioned_sidebars/.gitkeep
 docs/*
-!docs/.gitkeep
 sidebars.json
 static/assets/*
 versions.json

--- a/scripts/prepare-files.mts
+++ b/scripts/prepare-files.mts
@@ -9,6 +9,7 @@ import {
   getDocusaurusVersions,
 } from "../server/config-site";
 
+const DOCS_CURRENT_ROOT = "docs"
 const DOCS_PAGES_ROOT = "versioned_docs";
 const SIDEBAR_FILENAME = "sidebars.json";
 const VERSION_FILENAME = "versions.json";
@@ -34,6 +35,9 @@ const writeSidebar = (version: string) => {
 const writeVersions = () =>
   writeFileSync(VERSION_FILENAME, JSON.stringify(docusaurusVersions), "utf8");
 
+if (existsSync(DOCS_CURRENT_ROOT)) {
+  rmSync(DOCS_CURRENT_ROOT, { recursive: true });
+}
 if (existsSync(DOCS_PAGES_ROOT)) {
   rmSync(DOCS_PAGES_ROOT, { recursive: true });
 }
@@ -44,7 +48,7 @@ versions.forEach((version) => {
   const isCurrentVersion = version === currentVersion;
   const source = resolve("content", version, "docs/pages");
   const destination = isCurrentVersion
-    ? resolve("docs")
+    ? resolve(DOCS_CURRENT_ROOT)
     : resolve(DOCS_PAGES_ROOT, `version-${version}`);
 
   const paths = glob
@@ -82,7 +86,7 @@ const defaultUpcomingReleases = resolve(
 versionsToOverride.forEach((version) => {
   const destination =
     version === currentVersion
-      ? resolve("docs", "upcoming-releases.mdx")
+      ? resolve(DOCS_CURRENT_ROOT, "upcoming-releases.mdx")
       : resolve(DOCS_PAGES_ROOT, `version-${version}`, "upcoming-releases.mdx");
 
   copyFileSync(defaultUpcomingReleases, destination);


### PR DESCRIPTION
The script removes `versioned_docs`, but not `docs`, the directory where it copies MDX files from `docs/pages` in the current (i.e., edge) version. This means that, if we reorganize the docs in the current version on a local machine, the old file paths remain in the `docs` directory, causing builds to fail.