### PR TITLE
Update TypeScript and fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.7",
     "tsc-esm-fix": "^3.1.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "unified": "^11.0.5",
     "unified-lint-rule": "^3.0.0",
     "unist": "^0.0.1",

--- a/server/highlightjs-terraform.d.ts
+++ b/server/highlightjs-terraform.d.ts
@@ -1,0 +1,1 @@
+declare module 'highlightjs-terraform';

--- a/server/lint-frontmatter.ts
+++ b/server/lint-frontmatter.ts
@@ -40,7 +40,9 @@ export const remarkLintFrontmatter = lintRule(
       try {
         frontmatter = parse((node as Literal).value);
       } catch (err) {
-        vfile.message(`page has invalid YAML in frontmatter: ${err.message}`);
+        vfile.message(
+          `page has invalid YAML in frontmatter: ${(err as Error).message}`,
+        );
         return;
       }
 

--- a/server/lint-page-structure.ts
+++ b/server/lint-page-structure.ts
@@ -14,7 +14,7 @@ const mdxNodeTypes = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
 interface stepNumber {
   numerator: number;
   denominator: number;
-  position: Position;
+  position: Position | undefined;
 }
 
 interface h2WithIndex {
@@ -172,11 +172,10 @@ export const remarkLintPageStructure = lintRule(
               node.position,
             );
           }
-
           // Extract the name. We know that there is a valid name parameter, so
           // the array indices are guaranteed to be in range.
-          const namePattern = `name\\s*=\\s*${varQuote[1]}([^${varQuote[1]}]+)${varQuote[1]}`;
-          const varName = v[0].match(new RegExp(namePattern))[1];
+          const namePattern = `name\\s*=\\s*${varQuote![1]}([^${varQuote![1]}]+)${varQuote![1]}`;
+          const varName = v[0].match(new RegExp(namePattern))![1];
           if (!varNames.has(varName)) {
             varNames.set(varName, 0);
             varPositions.set(varName, code.position);

--- a/server/lint-teleport-docs-links.ts
+++ b/server/lint-teleport-docs-links.ts
@@ -53,7 +53,10 @@ export const remarkLintTeleportDocsLinks = lintRule(
           ({ name }) => name === "href",
         );
 
-        if (isAnAbsoluteDocsLink(hrefAttribute.value as string)) {
+        if (
+          hrefAttribute &&
+          isAnAbsoluteDocsLink(hrefAttribute.value as string)
+        ) {
           vfile.message(
             `Component href ${hrefAttribute.value} must be a relative link to an *.mdx page`,
             node.position,

--- a/server/llms/rehype-prepare-html.ts
+++ b/server/llms/rehype-prepare-html.ts
@@ -416,10 +416,11 @@ const rehypePrepareHTML: Plugin<[], Root, Root> = function () {
     // *** H1 repositioning: move the h1 to the top of the document ***
     if (h1 && headerParent) {
       const nodeToRemove = headerElement ?? h1;
-      headerParent.children = headerParent.children.filter(
+      const parent = headerParent as Element;
+      parent.children = parent.children.filter(
         (child) => child !== nodeToRemove,
       );
-      headerParent.children.unshift(h1);
+      parent.children.unshift(h1);
     }
   };
 };

--- a/server/postcss.ts
+++ b/server/postcss.ts
@@ -1,9 +1,10 @@
 import { resolve } from "path";
+import type { PostCssOptions } from "@docusaurus/types";
 
 export function extendedPostcssConfigPlugin() {
   return {
     name: "custom-postcss",
-    configurePostCss(options) {
+    configurePostCss(options: PostCssOptions) {
       // Appended pluigns, needed for the header
       options.plugins.push(
         [

--- a/server/redirects.ts
+++ b/server/redirects.ts
@@ -33,7 +33,7 @@ export const validateRedirects = (redirects: Array<CustomRedirect>) => {
 };
 
 const validateRedirect = (redirect: CustomRedirect) => {
-  ["source", "destination"].forEach((p) => {
+  (["source", "destination"] as const).forEach((p) => {
     if (isIndexPage(redirect[p])) {
       throw new Error(
         `redirect ${p} includes an incorrect category index page path - remove the final path segment: ${redirect[p]}`,

--- a/server/rehype-hljs.test.ts
+++ b/server/rehype-hljs.test.ts
@@ -20,7 +20,7 @@ describe("server/rehype-hljs-var", () => {
   const transformer = (options: VFileOptions) =>
     unified()
       .use(remarkParse as any)
-      .use(mdx)
+      .use(mdx as any)
       .use(remarkRehype as any, {
         passThrough: [
           "mdxFlowExpression",
@@ -30,7 +30,7 @@ describe("server/rehype-hljs-var", () => {
           "mdxjsEsm",
         ],
       })
-      .use(rehypeHLJS, {
+      .use(rehypeHLJS as any, {
         aliases: {
           bash: ["bsh", "systemd", "code", "powershell"],
         },

--- a/server/rehype-hljs.ts
+++ b/server/rehype-hljs.ts
@@ -24,16 +24,19 @@ const placeholderPattern = "var[a-z0-9]{32}";
 // We only visit text nodes inside code snippets that include either the
 // <Var tag or (if we have already swapped out Vars with placeholders) a
 // placeholder.
-const isPossibleVarContainer = (node: UnistParent) => {
+const isPossibleVarContainer = (node: Node) => {
+  const parent = node as UnistParent;
   return (
     node.type === "text" ||
     (node.type === "element" &&
-      node.children.length === 1 &&
-      node.children[0].type === "text")
+      parent.children.length === 1 &&
+      parent.children[0].type === "text")
   );
 };
 
-export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
+export const rehypeHLJS = (
+  options: RehypeHighlightOptions = {},
+): Transformer => {
   return (root: UnistNode, file: VFile) => {
     // Highlight common languages in addition to any additional configured ones.
     options.languages = { ...options.languages, ...common };
@@ -50,45 +53,45 @@ export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
     // In a code snippet, Var elements are parsed as text. Replace these with
     // UUID strings to ensure that the parser won't split these up and make
     // them unrecoverable.
-    visit(
-      root,
-      isPossibleVarContainer,
-      (node: UnistNode, index: number, parent: Parent) => {
-        const varPattern = new RegExp("<Var [^>]+/>", "g");
-        const unknownText = node as unknown;
-        let txt: Text;
-        if (node.type == "text") {
-          txt = unknownText as Text;
-        } else {
-          // isPossibleVarContainer enforces having a single child text node
-          txt = (unknownText as Parent).children[0] as Text;
-        }
+    visit(root, isPossibleVarContainer, ((
+      node: UnistNode,
+      index: number,
+      parent: Parent,
+    ) => {
+      const varPattern = new RegExp("<Var [^>]+/>", "g");
+      const unknownText = node as unknown;
+      let txt: Text;
+      if (node.type == "text") {
+        txt = unknownText as Text;
+      } else {
+        // isPossibleVarContainer enforces having a single child text node
+        txt = (unknownText as Parent).children[0] as Text;
+      }
 
-        const newVal = txt.value.replace(varPattern, (match) => {
-          const placeholder = makePlaceholder();
-          // Since the Var element was originally text, parse it so we can recover
-          // its properties. The result should be a small HTML AST with a root
-          // node and one child, the Var node.
-          const varParent = unified()
-            // Converting to "any" since, for some reason, the type of
-            // remarkParse doesn't match the signature of "use" despite this
-            // being a common use case in the unified documentation.
-            .use(remarkParse as any)
-            .use(remarkMDX)
-            // The parsed element begins with a root element, so get its first
-            // child, which is our Var.
-            .parse(match);
+      const newVal = txt.value.replace(varPattern, (match) => {
+        const placeholder = makePlaceholder();
+        // Since the Var element was originally text, parse it so we can recover
+        // its properties. The result should be a small HTML AST with a root
+        // node and one child, the Var node.
+        const varParent = unified()
+          // Converting to "any" since, for some reason, the type of
+          // remarkParse doesn't match the signature of "use" despite this
+          // being a common use case in the unified documentation.
+          .use(remarkParse as any)
+          .use(remarkMDX as any)
+          // The parsed element begins with a root element, so get its first
+          // child, which is our Var.
+          .parse(match);
 
-          const varElement = (varParent as Parent)
-            .children[0] as MdxJsxFlowElement;
+        const varElement = (varParent as Parent)
+          .children[0] as MdxJsxFlowElement;
 
-          placeholdersToVars[placeholder] = varElement;
-          return placeholder;
-        });
+        placeholdersToVars[placeholder] = varElement;
+        return placeholder;
+      });
 
-        txt.value = newVal;
-      },
-    );
+      txt.value = newVal;
+    }) as any);
 
     // Apply syntax highlighting
     (highlighter as Function)(root, file);
@@ -97,114 +100,114 @@ export const rehypeHLJS = (options?: RehypeHighlightOptions): Transformer => {
     // series of span elements with different "hljs-*" classes. Find the
     // placeholder UUIDs and replace them with their original Var elements,
     // inserting these as HTML AST nodes.
-    visit(
-      root,
-      isPossibleVarContainer,
-      (node: Node, index: number, parent: Parent) => {
-        const el = node as Element | Text;
-        let hljsSpanValue = "";
-        if (el.type === "text") {
-          hljsSpanValue = el.value;
-        } else {
-          hljsSpanValue = (el.children[0] as Text).value;
+    visit(root, isPossibleVarContainer, ((
+      node: Node,
+      index: number,
+      parent: Parent,
+    ) => {
+      const el = node as Element | Text;
+      let hljsSpanValue = "";
+      if (el.type === "text") {
+        hljsSpanValue = el.value;
+      } else {
+        hljsSpanValue = (el.children[0] as Text).value;
+      }
+
+      // This is either a text node or an hljs span with only the placeholder as
+      // its child. We don't need the node, so replace it with the original
+      // Var.
+      if (placeholdersToVars[hljsSpanValue]) {
+        (parent as any).children[index] = placeholdersToVars[hljsSpanValue];
+        return [CONTINUE];
+      }
+
+      const placeholders = Array.from(
+        hljsSpanValue.matchAll(new RegExp(placeholderPattern, "g")),
+      );
+
+      // No placeholders to recover, so there's nothing more to do.
+      if (placeholders.length == 0) {
+        return [CONTINUE];
+      }
+
+      // The element's text includes one or more Vars among other content, so we
+      // need to replace the span (or text node) with a series of spans (or
+      // text nodes) separated by Vars.
+      let newChildren: Array<Text | Element> = [];
+
+      // Assemble a map of indexes to their corresponding placeholders so we
+      // can tell whether a given index falls within a placeholder.
+      const placeholderIndices = new Map();
+      placeholders.forEach((p) => {
+        placeholderIndices.set(p.index, p[0]);
+      });
+
+      let valueIdx = 0;
+      while (valueIdx < hljsSpanValue.length) {
+        // The current index is in a placeholder, so add the original Var
+        // component to newChildren.
+        if (placeholderIndices.has(valueIdx)) {
+          const placeholder = placeholderIndices.get(valueIdx);
+          valueIdx += placeholder.length;
+          newChildren.push(placeholdersToVars[placeholder] as Element);
+          continue;
         }
-
-        // This is either a text node or an hljs span with only the placeholder as
-        // its child. We don't need the node, so replace it with the original
-        // Var.
-        if (placeholdersToVars[hljsSpanValue]) {
-          (parent as any).children[index] = placeholdersToVars[hljsSpanValue];
-          return [CONTINUE];
-        }
-
-        const placeholders = Array.from(
-          hljsSpanValue.matchAll(new RegExp(placeholderPattern, "g")),
-        );
-
-        // No placeholders to recover, so there's nothing more to do.
-        if (placeholders.length == 0) {
-          return [CONTINUE];
-        }
-
-        // The element's text includes one or more Vars among other content, so we
-        // need to replace the span (or text node) with a series of spans (or
-        // text nodes) separated by Vars.
-        let newChildren: Array<Text | Element> = [];
-
-        // Assemble a map of indexes to their corresponding placeholders so we
-        // can tell whether a given index falls within a placeholder.
-        const placeholderIndices = new Map();
-        placeholders.forEach((p) => {
-          placeholderIndices.set(p.index, p[0]);
-        });
-
-        let valueIdx = 0;
-        while (valueIdx < hljsSpanValue.length) {
-          // The current index is in a placeholder, so add the original Var
-          // component to newChildren.
-          if (placeholderIndices.has(valueIdx)) {
-            const placeholder = placeholderIndices.get(valueIdx);
-            valueIdx += placeholder.length;
-            newChildren.push(placeholdersToVars[placeholder] as Element);
-            continue;
-          }
-          // The current index is outside a placeholder, so assemble a text or
-          // span node and push that to newChildren.
-          let textVal = "";
-          while (
-            !placeholderIndices.has(valueIdx) &&
-            valueIdx < hljsSpanValue.length
-          ) {
-            textVal += hljsSpanValue[valueIdx];
-            valueIdx++;
-          }
-
-          if (el.type === "text") {
-            newChildren.push({
-              type: "text",
-              value: textVal,
-            });
-          } else {
-            // Add properties from any containing spans to preserve syntax
-            // highlighting.
-            let props: Record<string, any>;
-            if (el.tagName == "span") {
-              props = el.properties;
-            }
-            newChildren.push({
-              tagName: "span",
-              type: "element",
-              properties: props,
-              children: [
-                {
-                  type: "text",
-                  value: textVal,
-                },
-              ],
-            });
-          }
-        }
-
-        // Alter the final AST. This depends on the effects of syntax
-        // highlighting.
-        // The element is a text element or an hljs span containing a single
-        // text element, which results from highlighting a
-        // string. Replace the text element or hljs span.
-        if (
-          el.type === "text" ||
-          ((el as Element).tagName == "span" && el.children.length == 1)
+        // The current index is outside a placeholder, so assemble a text or
+        // span node and push that to newChildren.
+        let textVal = "";
+        while (
+          !placeholderIndices.has(valueIdx) &&
+          valueIdx < hljsSpanValue.length
         ) {
-          (parent.children as Array<Text | Element>).splice(
-            index,
-            1,
-            ...newChildren,
-          );
-        } else {
-          // Replace the children of the node.
-          (el.children as Array<Text | Element>) = newChildren;
+          textVal += hljsSpanValue[valueIdx];
+          valueIdx++;
         }
-        return [SKIP, index + newChildren.length];
-      },
-    );
+
+        if (el.type === "text") {
+          newChildren.push({
+            type: "text",
+            value: textVal,
+          });
+        } else {
+          // Add properties from any containing spans to preserve syntax
+          // highlighting.
+          let props: Record<string, any> = {};
+          if (el.tagName == "span") {
+            props = el.properties;
+          }
+          newChildren.push({
+            tagName: "span",
+            type: "element",
+            properties: props,
+            children: [
+              {
+                type: "text",
+                value: textVal,
+              },
+            ],
+          });
+        }
+      }
+
+      // Alter the final AST. This depends on the effects of syntax
+      // highlighting.
+      // The element is a text element or an hljs span containing a single
+      // text element, which results from highlighting a
+      // string. Replace the text element or hljs span.
+      if (
+        el.type === "text" ||
+        ((el as Element).tagName == "span" && el.children.length == 1)
+      ) {
+        (parent.children as Array<Text | Element>).splice(
+          index,
+          1,
+          ...newChildren,
+        );
+      } else {
+        // Replace the children of the node.
+        (el.children as Array<Text | Element>) = newChildren;
+      }
+      return [SKIP, index + newChildren.length];
+    }) as any);
   };
 };

--- a/server/rehype-mdx-to-hast.ts
+++ b/server/rehype-mdx-to-hast.ts
@@ -29,73 +29,76 @@ type MdxNode =
   | MdxFlowExpression // https://github.com/syntax-tree/mdast-util-mdx-expression/blob/main/complex-types.d.ts
   | MdxTextExpression; // https://github.com/syntax-tree/mdast-util-mdx-expression/blob/main/complex-types.d.ts
 
-export default function rehypeMdxToHast(): Transformer {
+export default function rehypeMdxToHast(): Transformer<Parent> {
   return (root: Parent) => {
-    visit(root, (node: any, index: number, parent: Parent) => {
-      // TextElement in an inline tag and FlowElement is a block tag. e want ot convert them.
-      if (
-        node.type === "mdxJsxTextElement" ||
-        node.type === "mdxJsxFlowElement"
-      ) {
-        const newNode = {
-          type: "element",
-          tagName: node.name.toLowerCase(),
-          properties: (node.attributes as MdxJsxAttribute[]).reduce(
-            (result, prop) => {
-              // If the prop in markdown was a js-expression like disabled={true}
-              // it will be parsed as an object with original value as a string
-              // and as a estree. For now we just use the string value.
-              if (typeof prop.value === "object" && prop.value !== null) {
-                // Temporary fix for scopeOnly={true}, can be removed after docs update
-                if (prop.name === "scopeOnly") {
+    visit(
+      root as any,
+      ((node: any, index: number, parent: Parent) => {
+        // TextElement in an inline tag and FlowElement is a block tag. e want ot convert them.
+        if (
+          node.type === "mdxJsxTextElement" ||
+          node.type === "mdxJsxFlowElement"
+        ) {
+          const newNode = {
+            type: "element",
+            tagName: node.name.toLowerCase(),
+            properties: (node.attributes as MdxJsxAttribute[]).reduce(
+              (result, prop) => {
+                // If the prop in markdown was a js-expression like disabled={true}
+                // it will be parsed as an object with original value as a string
+                // and as a estree. For now we just use the string value.
+                if (typeof prop.value === "object" && prop.value !== null) {
+                  // Temporary fix for scopeOnly={true}, can be removed after docs update
+                  if (prop.name === "scopeOnly") {
+                    return {
+                      ...result,
+                      [prop.name]: prop?.value?.value || null,
+                    };
+                    // Temporary fix for scope={["oss", "cloud"]}, will transform value
+                    // to scope="oss,cloud". Can be removed after docs update.
+                  } else if (prop.name === "scope") {
+                    return {
+                      ...result,
+                      [prop.name]: (
+                        prop.value as MdxJsxAttributeValueExpression
+                      ).value
+                        .split(",")
+                        .map((part) => part.replace(/[^a-z]+/g, ""))
+                        .join(","),
+                    };
+                  }
+
+                  // By default just return value as is. E. g. field={something}
+                  // will get value "{something}"" as is with curly braces.
                   return {
                     ...result,
-                    [prop.name]: prop?.value?.value || null,
-                  };
-                  // Temporary fix for scope={["oss", "cloud"]}, will transform value
-                  // to scope="oss,cloud". Can be removed after docs update.
-                } else if (prop.name === "scope") {
-                  return {
-                    ...result,
-                    [prop.name]: (
-                      prop.value as MdxJsxAttributeValueExpression
-                    ).value
-                      .split(",")
-                      .map((part) => part.replace(/[^a-z]+/g, ""))
-                      .join(","),
+                    [prop.name]: (prop.value as MdxJsxAttributeValueExpression)
+                      .value,
                   };
                 }
 
-                // By default just return value as is. E. g. field={something}
-                // will get value "{something}"" as is with curly braces.
+                // for non-js nodes just return value
                 return {
                   ...result,
-                  [prop.name]: (prop.value as MdxJsxAttributeValueExpression)
-                    .value,
+                  [prop.name]: prop.value === null ? true : prop.value,
                 };
-              }
+              },
+              {},
+            ),
+            children: node.children,
+          };
 
-              // for non-js nodes just return value
-              return {
-                ...result,
-                [prop.name]: prop.value === null ? true : prop.value,
-              };
-            },
-            {},
-          ),
-          children: node.children,
-        };
-
-        parent.children[index] = newNode;
-        // This is a pure JS nodes, like {1 + 1} or imports/exports.
-        // Just removing them for now for simplicity.
-      } else if (
-        ["mdxFlowExpression", "mdxTextExpression", "mdxjsEsm"].includes(
-          node.type,
-        )
-      ) {
-        parent.children.splice(index, 1);
-      }
-    });
+          parent.children[index] = newNode;
+          // This is a pure JS nodes, like {1 + 1} or imports/exports.
+          // Just removing them for now for simplicity.
+        } else if (
+          ["mdxFlowExpression", "mdxTextExpression", "mdxjsEsm"].includes(
+            node.type,
+          )
+        ) {
+          parent.children.splice(index, 1);
+        }
+      }) as any,
+    );
   };
 }

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -39,7 +39,7 @@ const RULE_ID = "code-snippet";
 const isCode =
   (langs: string[]) =>
   (node: Node): node is MdastCode =>
-    node.type === "code" && langs.includes((node as MdastCode).lang);
+    node.type === "code" && langs.includes((node as MdastCode).lang ?? "");
 
 const getTextChildren = (contentValue: string): Text => ({
   type: "text",
@@ -78,7 +78,7 @@ const getChildrenNode = (content: string): Array<Text | MdxJsxFlowElement> => {
   const nodeChildren: Array<Text | MdxJsxFlowElement> = [];
 
   if (hasVariable) {
-    const contentVars = content.match(/(?:\<Var .+?\/\>)/gm);
+    const contentVars = content.match(/(?:\<Var .+?\/\>)/gm)!;
     const firstPartLine = content.split("<Var")[0];
     nodeChildren.push(getTextChildren(firstPartLine));
     let newContent = content.replace("isGlobal", "");
@@ -86,7 +86,7 @@ const getChildrenNode = (content: string): Array<Text | MdxJsxFlowElement> => {
     for (let i = 0; i < contentVars.length; i++) {
       if (contentVars[i].includes("description=")) {
         newContent = newContent.replace(
-          contentVars[i].match(/description="(.*?)"/)[1],
+          contentVars[i].match(/description="(.*?)"/)![1],
           "",
         );
         newContent = newContent.replace('description=""', "");
@@ -97,10 +97,10 @@ const getChildrenNode = (content: string): Array<Text | MdxJsxFlowElement> => {
         nextPartLine = nextPartLine.split("<Var")[0];
       }
 
-      const varName = contentVars[i].match(/name="(.*?)"/)[1];
+      const varName = contentVars[i].match(/name="(.*?)"/)![1];
       const description =
         contentVars[i].includes("description=") &&
-        contentVars[i].match(/description="(.*?)"/)[1];
+        contentVars[i].match(/description="(.*?)"/)![1];
       const isGlobal = contentVars[i].includes("isGlobal");
       nodeChildren.push(getVariableNode(varName, isGlobal, description));
       nodeChildren.push(getTextChildren(nextPartLine));
@@ -136,7 +136,10 @@ const getCommandNode = (content: string, prefix = "$") => {
   };
 };
 
-const getLineNode = (content: string, attributes = []) => {
+const getLineNode = (
+  content: string,
+  attributes: Array<MdxJsxAttribute> = [],
+) => {
   const children = getChildrenNode(content);
 
   return {
@@ -190,7 +193,7 @@ export default function remarkCodeSnippet({
       (node: MdastCode, index, parent: MdxAnyElement) => {
         const content: string = node.value;
         const codeLines = content.split("\n");
-        const children = [];
+        const children: Array<any> = [];
 
         for (let i = 0; i < codeLines.length; i++) {
           const hasLeadingDollar = codeLines[i][0] === "$";
@@ -201,17 +204,17 @@ export default function remarkCodeSnippet({
           if (hasLeadingDollar) {
             children.push(getCommandNode(trimmedValue));
 
-            const commandArrayElem = children[children.length - 1].children;
+            const commandArrayElem = children[children.length - 1]!.children;
 
             if (codeLines[i].includes("<<")) {
-              let heredocMark = codeLines[i].match(/[^<<]*$/)[0].trim();
+              let heredocMark = codeLines[i].match(/[^<<]*$/)![0].trim();
 
               if (heredocMark.includes(">")) {
                 heredocMark = heredocMark.split(">")[0].trim();
               }
 
               if (heredocMark.includes("'")) {
-                heredocMark = heredocMark.match(/'(.*?)'/)[1];
+                heredocMark = heredocMark.match(/'(.*?)'/)![1];
               }
 
               if (heredocMark.indexOf("-") === 0) {

--- a/server/remark-includes.test.ts
+++ b/server/remark-includes.test.ts
@@ -27,7 +27,7 @@ const transformer = (
   return remark()
     .use(remarkMdx as any)
     .use(remarkGFM)
-    .use(remarkIncludes, {
+    .use(remarkIncludes as any, {
       rootDir: "server/fixtures/includes/",
       ...pluginOptions,
       updatePaths: updatePathsInIncludesTests,
@@ -47,7 +47,7 @@ const transformerAsJSON = (
     .parse(file as any);
 
   const result = remark()
-    .use(remarkIncludes, {
+    .use(remarkIncludes as any, {
       rootDir: "server/fixtures/includes/",
       ...pluginOptions,
       updatePaths: updatePathsInIncludesTests,
@@ -213,7 +213,7 @@ describe("server/remark-includes", () => {
 
     cases.forEach((c) => {
       if (c.shouldThrow == true) {
-        let val: string;
+        let val: string | undefined;
         try {
           val = resolveParamValue(c.input);
           assert.unreachable(
@@ -232,7 +232,7 @@ describe("server/remark-includes", () => {
         return;
       }
 
-      let val: string;
+      let val: string | undefined;
       try {
         val = resolveParamValue(c.input);
       } catch (err) {
@@ -337,7 +337,7 @@ describe("server/remark-includes", () => {
 
     test.each(cases)("$description", (c) => {
       if (c.shouldThrow) {
-        let val: ParameterAssignments;
+        let val: ParameterAssignments | undefined;
         try {
           val = parsePartialParams(c.input);
           assert.unreachable(
@@ -359,7 +359,7 @@ describe("server/remark-includes", () => {
       if (!c.expected) {
         return;
       }
-      let val: ParameterAssignments;
+      let val: ParameterAssignments | undefined;
       try {
         val = parsePartialParams(c.input);
       } catch (err) {
@@ -450,7 +450,7 @@ This is a partial.
 
     test.each(cases)("$description", (c) => {
       if (c.shouldThrow == true) {
-        let val: ParameterAssignments;
+        let val: ParameterAssignments | undefined;
         try {
           val = parseParamDefaults(c.input);
           assert.unreachable(
@@ -472,7 +472,7 @@ This is a partial.
       if (!c.expected) {
         return;
       }
-      let val: ParameterAssignments;
+      let val: ParameterAssignments | undefined;
       try {
         val = parseParamDefaults(c.input);
       } catch (err) {

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -214,7 +214,7 @@ const resolveIncludes = ({
   filePath,
   rootDir,
 }: ResolveIncludesProps) => {
-  let error: string;
+  let error: string | undefined;
 
   // Assemble an object where keys are the variable keys and values are the var
   // values.
@@ -331,7 +331,7 @@ export default function remarkIncludes({
   lint,
   resolve = true,
   updatePaths,
-}: RemarkIncludesOptions = {}): Transformer {
+}: RemarkIncludesOptions = {}): Transformer<Root> {
   return (root: Root, vfile: VFile) => {
     let resolvedRootDir: string;
 
@@ -347,7 +347,7 @@ export default function remarkIncludes({
       if (node.type === "code") {
         let code = node as Code;
         const noIncludes = numIncludes(code.value);
-        for (let i = 0; i < noIncludes; i++) {
+        for (let i = 0; i < (noIncludes ?? 0); i++) {
           const { result, error } = resolveIncludes({
             value: code.value,
             filePath: vfile.path,
@@ -375,7 +375,7 @@ export default function remarkIncludes({
                 rootDir: resolvedRootDir,
               });
 
-              const includeExpr = txt.value.match(exactIncludeRegexp)[1];
+              const includeExpr = txt.value.match(exactIncludeRegexp)![1];
               const path = includeExpr.split(" ")[0];
 
               // Parse the partial as a Markdown AST and insert it into the
@@ -399,7 +399,7 @@ export default function remarkIncludes({
 
                   // Replace relative paths in the partial so they match the
                   // directory structure of the including page.
-                  updatePaths({
+                  updatePaths?.({
                     node: tree as Root,
                     versionRootDir: resolvedRootDir,
                     includePath: path,

--- a/server/remark-no-h1.ts
+++ b/server/remark-no-h1.ts
@@ -11,7 +11,7 @@ const versionedDocsPattern = `versioned_docs/version-([0-9]+\\.x)/`;
 // engine uses the page's frontmatter to populate an H1. When including pages
 // that include a spearate H1, such as the changelog, we can ensure there are no
 // redundant H1s.
-export default function remarkNoH1(): Transformer {
+export default function remarkNoH1(): Transformer<Root> {
   return (root: Root, vfile: VFile) => {
     const par = root as Parent;
     let i = 0;

--- a/server/remark-update-asset-paths.ts
+++ b/server/remark-update-asset-paths.ts
@@ -23,13 +23,13 @@ const defaultUpdater: Updater = (href: string): string => href;
 const defaultAttributes = ["poster", "src", "href", "value"];
 
 const isNodeWithUrl = (node: unknown): node is Image | Link | Definition =>
-  node.hasOwnProperty("type") &&
+  Object.prototype.hasOwnProperty.call(node, "type") &&
   ["image", "link", "definition"].includes(
     (node as Image | Link | Definition).type,
   );
 
 const isMdxJsxElement = (node: unknown) =>
-  node.hasOwnProperty("type") &&
+  Object.prototype.hasOwnProperty.call(node, "type") &&
   ["mdxJsxFlowElement", "mdxJsxTextElement"].includes(
     (node as MdxJsxFlowElement | MdxJsxTextElement).type,
   );

--- a/server/remark-variables.ts
+++ b/server/remark-variables.ts
@@ -84,7 +84,7 @@ export default function remarkVariables({
   resolve = true,
   lint,
   variables = {} as Variables,
-}: RemarkVariablesOptions = {}): Transformer {
+}: RemarkVariablesOptions = {}): Transformer<Root> {
   return (root: Root, vfile) => {
     let resolvedVariables: Variables;
 

--- a/server/remark-version-alias.ts
+++ b/server/remark-version-alias.ts
@@ -7,7 +7,9 @@ import { visit, CONTINUE, SKIP } from "unist-util-visit";
 
 const versionedDocsPattern = `versioned_docs/version-([0-9]+\\.x)/`;
 
-export default function remarkVersionAlias(currentVersion: string): Transformer {
+export default function remarkVersionAlias(
+  currentVersion: string,
+): Transformer<Root> {
   return (root: Root, vfile: VFile) => {
     visit(root, (node: Node) => {
       if (node.type != "mdxjsEsm") {

--- a/server/sidebar-order.test.ts
+++ b/server/sidebar-order.test.ts
@@ -506,7 +506,7 @@ describe("orderSidebarItems", () => {
   });
 
   describe("sidebar position", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "page-a": {
         title: "Page A",
         id: "page-a",
@@ -761,7 +761,7 @@ describe("orderSidebarItems", () => {
   });
 
   describe("sidebar label", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "page-a": {
         title: "Page A",
         id: "page-a",
@@ -911,7 +911,7 @@ describe("orderSidebarItems", () => {
   });
 
   describe("ordering category index pages", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "section-a/section-a": {
         title: "Section A",
         id: "section-a/section-a",
@@ -1082,7 +1082,7 @@ describe("orderSidebarItems", () => {
   });
 
   test("identical sidebar positions", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "page-a": {
         title: "Page A",
         id: "page-a",
@@ -1134,7 +1134,7 @@ describe("orderSidebarItems", () => {
   });
 
   test("identical sidebar position with a 'category' type sidebar item", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "section-b/section-b": {
         title: "Section B",
         id: "section-b/section-b",
@@ -1185,7 +1185,7 @@ describe("orderSidebarItems", () => {
   });
 
   test("sidebar position out of bounds", () => {
-    const idToDocPage = {
+    const idToDocPage: Record<string, docPage> = {
       "page-a": {
         title: "Page A",
         id: "page-a",

--- a/server/sidebar-order.ts
+++ b/server/sidebar-order.ts
@@ -30,10 +30,10 @@ interface orderAttributes {
 const getOrderAttributes = (
   item: NormalizedSidebarItem,
   getter: (id: string) => docPage,
-): orderAttributes => {
+): orderAttributes | undefined => {
   let title: string;
-  let sidebarPosition: number;
-  let id: string;
+  let sidebarPosition: number | undefined;
+  let id: string | undefined;
   switch (item.type) {
     case "doc":
       const page = getter((item as SidebarItemDoc).id);
@@ -71,7 +71,7 @@ export const orderSidebarItems = (
   getter: (id: string) => docPage,
 ): Array<NormalizedSidebarItem> => {
   const newItems = new Array(items.length);
-  const unsortedItems = [];
+  const unsortedItems: Array<NormalizedSidebarItem> = [];
 
   items.forEach((item) => {
     // Start by recursively descending into items and sorting their children.
@@ -84,7 +84,7 @@ export const orderSidebarItems = (
     // If the item has a sidebar position, add it to the final array. We'll sort
     // the remaining items automatically before adding them to the empty slots
     // in the final array.
-    const { sidebarPosition, id } = getOrderAttributes(newItem, getter);
+    const { sidebarPosition, id } = getOrderAttributes(newItem, getter) ?? {};
     if (!sidebarPosition) {
       unsortedItems.push(newItem);
       return;
@@ -99,7 +99,8 @@ export const orderSidebarItems = (
     const sideBarIndex = sidebarPosition - 1;
 
     if (newItems[sideBarIndex]) {
-      const conflictingPageId = getOrderAttributes(newItems[sideBarIndex], getter)?.id ?? "[unknown]";
+      const conflictingPageId =
+        getOrderAttributes(newItems[sideBarIndex], getter)?.id ?? "[unknown]";
       throw new Error(
         `page with ID ${id} has the same sidebar_position frontmatter value as the page with ID ${conflictingPageId} in the same sidebar section`,
       );

--- a/server/youtube-meta.ts
+++ b/server/youtube-meta.ts
@@ -153,7 +153,7 @@ export async function fetchVideoMeta(id: string): Promise<Meta> {
         title: rawDataItem.snippet.title,
         description: extractYouTubeVideoDescription(
           rawDataItem.snippet.description
-        ),
+        ) ?? undefined,
         thumbnail: rawDataItem.snippet.thumbnails.medium.url,
         duration: changeFormatDuration(rawDataItem.contentDetails.duration),
       };

--- a/src/utils/suggestions.test.ts
+++ b/src/utils/suggestions.test.ts
@@ -11,7 +11,7 @@ describe("possibleMovedPages", () => {
     description: string;
     slug: string;
     versions: Array<DocsVersion>;
-    expected: Array<DocPathInfo>;
+    expected: Array<DocPathInfo> | undefined;
   }
 
   const testCases: Array<testCase> = [
@@ -152,7 +152,7 @@ describe("nearestAvailableCategoryIndex", () => {
     description: string;
     slug: string;
     versions: Array<DocsVersion>;
-    expected: DocPathInfo;
+    expected: DocPathInfo | undefined;
   }
 
   const testCases: Array<testCase> = [

--- a/src/utils/suggestions.ts
+++ b/src/utils/suggestions.ts
@@ -29,7 +29,7 @@ export const possibleMovedPages = function (
     v.docs.forEach((d) => {
       // Obtain the slug from the page ID. This is guaranteed to match the
       // expression since it comes from Docusaurus.
-      const name = d.id.match(/[^\/]+$/)[0];
+      const name = d.id.match(/[^\/]+$/)![0];
       if (!slugsToPathInfo.has(name)) {
         slugsToPathInfo.set(name, [d]);
         return;
@@ -72,7 +72,7 @@ function getPathDir(path: string): string {
 export const nearestAvailableCategoryIndex = function (
   urlpath: string,
   nav: Array<DocsVersion>,
-): DocPathInfo {
+): DocPathInfo | undefined {
   const sectionIndexMap = new Map();
   nav.forEach((v) => {
     if (!urlpath.startsWith(v.path)) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -9,13 +9,14 @@ export const splitPath = (fullPath: string): URLParts => {
   const [path, search] = rest.split("?");
   const query: Record<string, string> = !search
     ? {}
-    : search.split("&").reduce((result, segment) => {
-        const [key, value] = segment.split("=");
-
-        result[key] = value;
-
-        return result;
-      }, {});
+    : search.split("&").reduce(
+        (result, segment) => {
+          const [key, value] = segment.split("=");
+          result[key] = value;
+          return result;
+        },
+        {} as Record<string, string>,
+      );
 
   return { anchor, path, query };
 };

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,8 +5,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
-    "baseUrl": ".",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "outDir": ".remark-build"
   },

--- a/tsconfig.storybook.json
+++ b/tsconfig.storybook.json
@@ -5,13 +5,7 @@
     "jsx": "react-jsx",
     "allowJs": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "baseUrl": ".",
-    "paths": {
-      "/src/*": ["./src/*"],
-      "/utils/*": ["./utils/*"]
-    }
+    "module": "esnext"
   },
   "include": [
     ".storybook/@types/**/*.d.ts",

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -15,10 +15,13 @@ export const toCopyContent = (
 ): string => {
   const lines = Array.from(
     commandNode.querySelectorAll(commandLineClasses.join(",")),
-  ).reduce((allLines, commandLine) => {
-    allLines.push(commandLine.textContent);
-    return allLines;
-  }, []);
+  ).reduce(
+    (allLines, commandLine) => {
+      allLines.push(commandLine.textContent);
+      return allLines;
+    },
+    [] as (string | null)[],
+  );
   return lines.join("\n");
 };
 
@@ -70,8 +73,8 @@ export const getFromSecretOrEnv = (name: string): string => {
  */
 export const getVersionedUrl = (
   version: PropVersionMetadata,
-  href?: string
-): string => {
+  href?: string,
+): string | undefined => {
   const { isLast, label } = version;
   const isProduction = typeof process !== "undefined" && process.env.AWS_APP_ID;
   const basePath = isProduction ? "/docs" : "";

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -17,7 +17,7 @@ export const splitPath = (fullPath: string): URLParts => {
         result[key] = value;
 
         return result;
-      }, {});
+      }, {} as Record<string, string>);
 
   return { anchor, path, query };
 };
@@ -81,7 +81,7 @@ export const getExtension = (href: string): string | undefined => {
 
   if (filename.indexOf(".") !== -1) {
     // should catch double extensions like `.tag.gz` and `.gitignore`
-    return /[^.]*\.(.+)/.exec(filename)[1];
+    return /[^.]*\.(.+)/.exec(filename)![1];
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17029,10 +17029,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@~5.9.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@~6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ufo@^1.6.1:
   version "1.6.3"


### PR DESCRIPTION
TypeScript 6 introduced stricter type checks, so fix the types in the source to accommodate them.

- Explicit generic type parameters: e.g. `Transformer<Root>` instead of `Transformer`
- `as any` at `.use()` call sites: TS6 no longer simplifies the `Plugin`/`BuildVisitor` conditional types
- Non-null assertions (`!`) on `.match()` and array index results: these values are guaranteed to be non-null by surrounding logic
- Explicit type annotations on empty array/object initializers: `{}`, `[]` where the inferred type was too broad or unresolvable without a annotation
- Nullish coalescing (`??`) and optional chaining (`?.`) to handle potentially null/undefined values
- `as const` on array literals: to produce string literal union types instead of `string[]`, required for indexed-access narrowing in TS6
- `(err as Error)` in catch bodies
- Add a `server/highlightjs-terraform.d.ts` to satisfy TS6's ambient module declaration requirement