### PR TITLE
Adding AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md
+
+Teleport docs website: a multi-version Docusaurus site.
+  
+## Content workflow
+
+Docs page content changes belong in the target version under `content/[version]/docs/pages/`. Files in `includes/` directories are reusable snippets, not standalone pages.
+
+Docs site implementation changes belong outside `content/`, usually in `src/`, `server/`, `scripts/`, `static/`, `data/`, or root config files.
+
+Do not edit `docs/`, `versioned_docs/`, `versioned_sidebars/`, or `sidebars.json` directly for docs content changes; those files are generated from `content/[version]/` by `yarn prepare-files` based on the version structure in `config.json`.
+
+## Commands
+
+```bash
+yarn prepare-files              # Rebuild docs/, versioned_docs/, sidebars.json, and versioned_sidebars/ from content/.
+yarn prepare-navigation-data    # Refresh navbar/event data in data/.
+yarn markdown-lint              # Lint MDX docs content. Does not auto-fix; errors must be corrected manually.
+yarn lint-check                 # Check JS/TS/JSON formatting and linting.
+yarn typecheck                  # TypeScript validation.
+yarn test                       # Jest tests for src/ and server/.
+yarn clear                      # Clear Docusaurus cache.
+```
+
+Command side effects:
+
+- `yarn build` runs `yarn git-update`, `yarn prepare-files`, `yarn prepare-navigation-data`, then `docusaurus build`; it can update submodules and rewrite generated docs output.
+- `yarn git-update` updates submodules to configured remote branches.
+- `yarn dev` runs local setup/watch scripts and may install macOS Homebrew dependencies such as `rsync`, `watchexec`, and `jq`.
+- For a local production build without submodule updates, use `yarn prepare-files && yarn prepare-navigation-data && yarn docusaurus build`.
+
+## Boundaries
+
+Ask first:
+
+- Adding, removing, or changing versions in `config.json`.
+- Modifying `.gitmodules`, submodule structure, or manually updating submodule refs.
+- Running `yarn git-update` when not explicitly requested.
+- Changing `docusaurus.config.ts`, custom remark/rehype plugins, or build pipeline behavior in `server/`.
+- Installing dependencies or changing package manager files.
+- Modifying CI/CD workflows in `.github/workflows/`.
+
+## MDX rules
+
+New MDX content pages, excluding `includes/` pages, need at least:
+
+```yaml
+---
+title: "Page Title"
+description: "Short SEO description"
+---
+```
+
+Common optional fields:
+
+```yaml
+sidebar_label: "Nav Label"
+sidebar_position: 1
+tags: 
+ - tag1
+ - tag2
+```
+
+Use frontmatter fields from `frontmatter_fields.yaml` and tags from `tags.yml`.
+
+Special syntax:
+
+```mdx
+(!docs/pages/includes/snippet.mdx!)
+(=teleport.version=)
+```
+
+Prefer relative `.mdx` links for internal docs pages, e.g. `[Install Teleport](../installation/single-machine/single-machine.mdx)`. Do not use absolute `https://goteleport.com/docs/...` links for internal docs pages.
+
+## Verification
+
+For docs content verification from the docs-website root:
+
+```bash
+yarn prepare-files
+yarn markdown-lint
+```
+
+Run `yarn prepare-navigation-data` when checking site navigation or doing a full local site build.
+
+For site, script, or server code changes:
+
+```bash
+yarn lint-check
+yarn typecheck
+yarn test
+```
+
+## Testing guidelines
+
+### Unit tests
+
+Write unit tests for components or utilities with complex logic. Extract logic into testable functions when possible.
+
+Examples in the codebase:
+- `src/utils/suggestions.test.ts` - Tests for page suggestion algorithms
+- `server/remark-variables.test.ts` - Tests for MDX transformation plugins
+
+Unit tests should live alongside the code they test (`.test.ts` or `.test.tsx` files)
+
+### Storybook tests
+
+For components with non-trivial user interactions (forms, buttons with state changes, multi-step flows), add Storybook stories with interaction tests.
+
+Example in the codebase:
+- `src/components/ThumbsFeedback/ThumbsFeedback.stories.tsx` - Tests user clicking feedback buttons, typing comments, and submitting
+
+## Additional references
+
+- Markdown linting rules: `.remarkrc.mjs`
+- Build configuration: `docusaurus.config.ts`


### PR DESCRIPTION
This PR adds a minimal AGENTS.md file to give LLMs and agents, used by contributors, context around the docs-website repo.

This first pass was intentionally minimal with an aim of under 100 lines. Ideally, the shorter this file, the better, as it runs on every agent call, and current data says over ~200 lines begins to introduce performance and quality loss. 

Also, this is a living file. Instead of adding bulk context up front, contributors can add (or update) progressively as needed when discrepancies or gaps are discovered.

NOTE: CLAUDE does not recognize AGENTS.md so will need to either symlink or add a task in CI to copy AGENTS.md to a CLAUDE.md file, letting AGENTS.md be the source of truth, so that Claude users can benefit (which I think most of us use). That being said, I can create them both for now if reviewers think it's prudent, or explore other options as well. 