### PR TITLE
Update the placeholder of the `<BrowserOnly>` fallback input in `InlineSearch`

### DIFF
--- a/src/components/Pages/Homepage/DocsHeader/InlineSearch.tsx
+++ b/src/components/Pages/Homepage/DocsHeader/InlineSearch.tsx
@@ -53,7 +53,7 @@ export function InlineSearch({
           fallback={
             <input
               className={styles.searchInput}
-              placeholder="Search Docs or Press ⌘ + K"
+              placeholder="Search Documentation (⌘ + K)"
               readOnly
             />
           }


### PR DESCRIPTION
The placeholder value of the fallback input still had the previous version of the text. This PR updates it to match the placeholder text of the actual input to prevent the fallback text changing during React hydration.