### PR TITLE
docs: update docs signup link

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -82,7 +82,7 @@ const Header = () => {
           <Button
             as="link"
             className={styles.cta}
-            href="https://goteleport.com/support/"
+            href="https://goteleport.com/signup/"
             variant="primary"
             shape="md"
           >


### PR DESCRIPTION
This commit fixes the docs "Try for Free" signup link in the Header. It is currently going to `/support` and is now being changed correctly to `/signup`.