### PR TITLE
Analytics: add custom events for copy/view as Markdown buttons

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,9 @@ const config: StorybookConfig = {
       ...config.resolve.alias,
       "@docusaurus/router": path.resolve(__dirname, "./mocks/docusaurus-router.ts"),
       "@docusaurus/Link": path.resolve(__dirname, "./mocks/docusaurus-link.tsx"),
+      "@docusaurus/BrowserOnly": path.resolve(__dirname, "./mocks/docusaurus-browser-only.tsx"),
+      "@docusaurus/theme-common": path.resolve(__dirname, "./mocks/docusaurus-theme-common.ts"),
+      "@docusaurus/useDocusaurusContext": path.resolve(__dirname, "./mocks/docusaurus-use-docusaurus-context.ts"),
       "@site": path.resolve(__dirname, ".."),
     };
 

--- a/.storybook/mocks/docusaurus-browser-only.tsx
+++ b/.storybook/mocks/docusaurus-browser-only.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+interface BrowserOnlyProps {
+  children: () => React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+const BrowserOnly: React.FC<BrowserOnlyProps> = ({ children }) => {
+  return <>{children()}</>;
+};
+
+export default BrowserOnly;

--- a/.storybook/mocks/docusaurus-theme-common.ts
+++ b/.storybook/mocks/docusaurus-theme-common.ts
@@ -1,0 +1,3 @@
+export function useWindowSize() {
+  return "desktop";
+}

--- a/.storybook/mocks/docusaurus-use-docusaurus-context.ts
+++ b/.storybook/mocks/docusaurus-use-docusaurus-context.ts
@@ -1,0 +1,14 @@
+export default function useDocusaurusContext() {
+  return {
+    siteConfig: {
+      title: "Docs",
+      url: "https://goteleport.com",
+      baseUrl: "/docs/",
+      customFields: {
+        inkeepConfig: {
+            apiKey: "fake-api-key",
+        }
+      },
+    },
+  };
+}

--- a/src/components/PageActions/PageActions.stories.tsx
+++ b/src/components/PageActions/PageActions.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+import { expect } from "@storybook/test";
+import React, { useState } from "react";
+import PageActions from "./PageActions";
+import ThumbsFeedbackContext from "../ThumbsFeedback/context";
+import { FeedbackType } from "../ThumbsFeedback/types";
+import { collectEvents } from "/src/utils/analytics";
+
+// Need to wrap PageActions with the ThumbsFeedbackContext provider since the inner ThumbsFeedback uses the context
+const WithFeedbackContext: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [feedback, setFeedback] = useState<FeedbackType | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  return (
+    <ThumbsFeedbackContext.Provider
+      value={{ feedback, setFeedback, isSubmitted, setIsSubmitted }}
+    >
+      {children}
+    </ThumbsFeedbackContext.Provider>
+  );
+};
+
+const meta: Meta<typeof PageActions> = {
+  title: "components/PageActions",
+  component: PageActions,
+};
+
+export default meta;
+type Story = StoryObj<typeof PageActions>;
+
+export const InitialState: Story = {
+  render: () => (
+    <WithFeedbackContext>
+      <PageActions pathname="/test" emitEvent={collectEvents()} />
+    </WithFeedbackContext>
+  ),
+};
+
+export const CopyForLLMClick: Story = {
+  render: () => (
+    <WithFeedbackContext>
+      <PageActions pathname="/test" emitEvent={collectEvents()} />
+    </WithFeedbackContext>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click 'Copy for LLM' button", async () => {
+      await userEvent.click(canvas.getByText("Copy for LLM"));
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "copy_page_as_markdown",
+      });
+    });
+  },
+};
+
+export const ViewAsMarkdownClick: Story = {
+  render: () => (
+    <WithFeedbackContext>
+      <PageActions pathname="/test" emitEvent={collectEvents()} />
+    </WithFeedbackContext>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click 'View as Markdown' button", async () => {
+      await userEvent.click(canvas.getByText("View as Markdown"));
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "view_page_as_markdown",
+      });
+    });
+  },
+};

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -10,8 +10,14 @@ import {
 } from "@site/src/utils/markdown";
 import { useMemo, useRef, useState } from "react";
 import { useWindowSize } from "@docusaurus/theme-common";
+import { trackEvent } from "@site/src/utils/analytics";
 
-const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
+type PageActionsProps = {
+  pathname: string;
+  emitEvent?: (name: string, params: any) => {};
+};
+
+const PageActions: React.FC<PageActionsProps> = ({ pathname, emitEvent }) => {
   const { setIsOpen, ModalSearchAndChat, inkeepModalProps } = useInkeepSearch({
     enableAIChat: true,
   });
@@ -42,6 +48,10 @@ const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
         }
         ref={copyButtonRef}
         onClick={() => {
+          trackEvent({
+            event_name: `copy_page_as_markdown`,
+            emitEvent: emitEvent,
+          });
           copyPageContentAsMarkdown(pathname);
           setCopiedMessage("Copied!");
           setTimeout(() => setCopiedMessage("Copy for LLM"), 3000);
@@ -54,6 +64,12 @@ const PageActions: React.FC<{ pathname: string }> = ({ pathname }) => {
         className={styles.askAIButton}
         href={normalizeMarkdownPathname(pathname)}
         target="_blank"
+        onClick={() => {
+          trackEvent({
+            event_name: `view_page_as_markdown`,
+            emitEvent: emitEvent,
+          });
+        }}
       >
         <Icon size="md" name="markdown" />
         <span>View as Markdown</span>


### PR DESCRIPTION
This PR adds two new custom Google Analytics (GA) events for tracking clicks to the "Copy for LLM" / "View as Markdown" buttons in the `PageActions` component.

The new custom events:
- `copy_page_as_markdown`
- `view_page_as_markdown`

Additional changes:
- Adds Storybook interaction tests for the `PageActions` component in `PageActions.stories.tsx` to ensure that the GA events are firing expectedly.
- For the new Storybook test file to work, it was required to add mocks for Docusaurus's `BrowserOnly`, `useWindowSize`, and `useDocusaurusContext` utilities.