### PR TITLE
Docs: Preserve casing of external URLs with fragments

### DIFF
--- a/server/asset-path-helpers.ts
+++ b/server/asset-path-helpers.ts
@@ -85,8 +85,19 @@ export const updateAssetPath = (href: string, { vfile }: { vfile: VFile }) => {
     return relative(dirname(vfile.path), assetPath);
   }
 
+  // Leave external URLs untouched — their paths and fragments are
+  // case-sensitive and should not be modified.
+  if (/^https?:\/\//i.test(href) || href.startsWith("//")) {
+    return href;
+  }
+
+  // For internal links, lowercase only the fragment so it matches
+  // Docusaurus's slugified heading IDs.
   if (href.includes("#")) {
-    return href.toLowerCase();
+    const hashIndex = href.indexOf("#");
+    const path = href.slice(0, hashIndex);
+    const fragment = href.slice(hashIndex + 1);
+    return `${path}#${fragment.toLowerCase()}`;
   }
 
   return href;


### PR DESCRIPTION
**Resolves:**
https://github.com/gravitational/docs-website/issues/665

The docs build engine lowercases the entirety of any URL containing a # fragment, including external URLs. Since URL paths and fragments are case-sensitive per RFC 3986, and AWS, Azure, GCP, and many other vendor docs rely on mixed-case paths and anchor IDs, this rewrites valid external links into broken ones (the lowercased URL either 404s or fails to scroll to the intended anchor.)

**Proposed fix**
Skip external URLs entirely, and for internal links lowercase only the fragment.
This preserves existing behavior for internal links (a grep of docs/pages/ finds ~47 internal links with mixed-case fragments that depend on this normalization) while fixing the external-URL case.

External URLs found:
```
% ggrep -rnoP "https?://(?=[^\s\"'<>()[\]]*[A-Z])[^\s\"'<>()[\]]*#[^\s\"'<>()[\]]*" *| wc -l
      86
```

Reference Doc PR this came up in:
https://github.com/gravitational/teleport/pull/66723