### PR TITLE
Use JSON Schema to validate docs frontmatter

### DIFF
--- a/frontmatter_fields.yaml
+++ b/frontmatter_fields.yaml
@@ -1,35 +1,73 @@
-# Permitted fields for docs page frontmatter
-allowedFields:
+# Permitted fields for docs page frontmatter.
+# This is a JSON Schema document.
+type: object
+additionalProperties: false
+properties:
   # The fields below are used natively by Docusaurus. See the Docusaurus docs:
   # https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter
-  - custom_edit_url
-  - description
-  - displayed_sidebar
-  - draft
-  - hide_table_of_contents
-  - hide_title
-  - id
-  - image
-  - keywords
-  - last_update
-  - pagination_label
-  - pagination_next
-  - pagination_prev
-  - parse_number_prefixes
-  - sidebar_class_name
-  - sidebar_custom_props
-  - sidebar_key
-  - sidebar_label
-  - sidebar_position
-  - slug
-  - tags
-  - title
-  - toc_max_heading_level
-  - toc_min_heading_level
-  - unlisted
+  title:
+    type: string
+  description:
+    type: string
+  hide_title:
+    type: boolean
+  hide_table_of_contents:
+    type: boolean
+  draft:
+    type: boolean
+  unlisted:
+    type: boolean
+  parse_number_prefixes:
+    type: boolean
+  id:
+    type: string
+  slug:
+    type: string
+  sidebar_label:
+    type: string
+  sidebar_key:
+    type: string
+  sidebar_class_name:
+    type: string
+  sidebar_position:
+    type: integer
+  pagination_label:
+    type: string
+  image:
+    type: string
+  displayed_sidebar:
+    type: [string, "null"]
+  custom_edit_url:
+    type: [string, "null"]
+  pagination_next:
+    type: [string, "null"]
+  pagination_prev:
+    type: [string, "null"]
+  toc_min_heading_level:
+    type: integer
+    minimum: 2
+    maximum: 6
+  toc_max_heading_level:
+    type: integer
+    minimum: 2
+    maximum: 6
+  keywords:
+    type: array
+    items:
+      type: string
+  tags:
+    type: array
+    items: {}
+  last_update:
+    type: object
+  sidebar_custom_props:
+    type: object
 
   # The fields below are used in custom components
-  - template
-  - videoBanner
-  - videoBannerDescription
-  - enterprise
+  enterprise: {}
+  template:
+    type: string
+  videoBanner:
+    type: string
+  videoBannerDescription:
+    type: string

--- a/server/lint-frontmatter.test.ts
+++ b/server/lint-frontmatter.test.ts
@@ -12,7 +12,20 @@ const getReasons = (value: string) => {
       // remark-frontmatter is a requirement for using this plugin
       .use(remarkFrontmatter as any)
       .use(remarkLintFrontmatter as any, {
-        allowedFields: ["title", "description", "tags"],
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: {
+            type: "string",
+          },
+          description: {
+            type: "string",
+          },
+          tags: {
+            type: "array",
+            items: {},
+          },
+        },
       })
       .processSync(new VFile({ value, path: "mypath.mdx" }) as any)
       .messages.map((m) => m.reason)
@@ -94,6 +107,15 @@ title: \"My page\",
                 ^
 `,
       ],
+    },
+    {
+      description: "valid yaml that is not an object",
+      input: `---
+["one", "two", "three"]
+---
+
+This is a page.`,
+      expected: [`page frontmatter must be a YAML object`],
     },
     {
       description: "no frontmatter",

--- a/server/lint-frontmatter.ts
+++ b/server/lint-frontmatter.ts
@@ -3,6 +3,8 @@ import { visit } from "unist-util-visit";
 import type { Node } from "unist";
 import { parse } from "yaml";
 import type { Literal } from "mdast";
+import type { JSONSchema7 } from "json-schema";
+import Ajv from "ajv";
 
 const possibleProducts = [
   "identity-governance",
@@ -27,16 +29,23 @@ interface LintFrontmatterOptions {
 
 export const remarkLintFrontmatter = lintRule(
   "remark-lint:frontmatter",
-  (root: Node, vfile, options: LintFrontmatterOptions) => {
+  (root: Node, vfile, options: JSONSchema7) => {
+    // Ensure additionalProperties is false. The point of this linter is to
+    // prevent misspelled or removed frontmatter fields from making it into
+    // the docs and causing unintended behavior or confusion for maintainers.
+    options.additionalProperties = false;
+
     let hasFrontmatter = false;
-    const { allowedFields } = options;
-    const allowedSet = new Set(allowedFields);
+    const ajv = new Ajv({
+      allErrors: true,
+    });
+    const validate = ajv.compile(options);
 
     visit(root, "yaml", (node: Node) => {
       hasFrontmatter = true;
 
       // Include frontmatter parsing errors as linting errors.
-      let frontmatter;
+      let frontmatter: Record<string, any>;
       try {
         frontmatter = parse((node as Literal).value);
       } catch (err) {
@@ -52,14 +61,37 @@ export const remarkLintFrontmatter = lintRule(
         return;
       }
 
-      const actual = new Set(Object.keys(frontmatter));
-      const extraFields = [...actual.difference(allowedSet)];
+      const valid = validate(frontmatter);
+      if (valid) {
+        return;
+      }
+
+      const extraFields: Array<string> = [];
+      validate.errors!.forEach((e) => {
+        switch (e.keyword) {
+          case "type":
+            // Ignore specific type errors for now. The linter focuses on
+            // additional properties and overall malformed frontmatter, so
+            // check whether the whole frontmatter document is an incorrect
+            // type.
+            if (e.instancePath !== "") {
+              return;
+            }
+            vfile.message("page frontmatter must be a YAML object");
+            return;
+
+          case "additionalProperties":
+            extraFields.push(e.params.additionalProperty);
+        }
+      });
+
       if (extraFields.length > 0) {
         vfile.message(
           `page frontmatter has unrecognized fields: ${extraFields.join(", ")}`,
         );
       }
     });
+
     if (!hasFrontmatter) {
       vfile.message(
         `the page must begin with a YAML frontmatter document surrounded by "---" separators`,


### PR DESCRIPTION
Edit lint-frontmatter.ts to support JSON Schema. This gives us more flexibility for implementing additional validation, such as specific values of an enum field.

In this change, lint-frontmatter.ts only checks for additional properties to be consistent with its current test specs.

The current implementation of lint-frontmatter implicitly handles situations in which the frontmatter is valid YAML but not an object. This change needs to add an explicit check for an invalid frontmatter type.