### PR TITLE
Support an optional page_type frontmatter field

### DIFF
--- a/frontmatter_fields.yaml
+++ b/frontmatter_fields.yaml
@@ -63,8 +63,19 @@ properties:
   sidebar_custom_props:
     type: object
 
-  # The fields below are used in custom components
+  # The fields below are used in custom components and linters
   enterprise: {}
+  page_type:
+    enum:
+      # Make page_type an optional frontmatter field until we can roll it out
+      # across the docs. 
+      - null 
+      - conceptual
+      - faq
+      - how-to # Includes getting started tutorials
+      - landing
+      - reference
+      - troubleshooting
   template:
     type: string
   videoBanner:

--- a/server/lint-frontmatter.test.ts
+++ b/server/lint-frontmatter.test.ts
@@ -25,6 +25,9 @@ const getReasons = (value: string) => {
             type: "array",
             items: {},
           },
+          kind: {
+            enum: ["kind1", "kind2", null],
+          },
         },
       })
       .processSync(new VFile({ value, path: "mypath.mdx" }) as any)
@@ -77,7 +80,9 @@ description: "Description for my page"
 labels: ["one", "two", "three"]
 ---
 This is a page.`,
-      expected: ["page frontmatter has unrecognized fields: labels"],
+      expected: [
+        'issue validating page frontmatter: unexpected property "labels"',
+      ],
     },
     {
       description: "two extra fields",
@@ -89,7 +94,8 @@ labels: ["one", "two", "three"]
 
 This is a page.`,
       expected: [
-        "page frontmatter has unrecognized fields: descrption, labels",
+        'issue validating page frontmatter: unexpected property "descrption"',
+        'issue validating page frontmatter: unexpected property "labels"',
       ],
     },
     {
@@ -115,7 +121,16 @@ title: \"My page\",
 ---
 
 This is a page.`,
-      expected: [`page frontmatter must be a YAML object`],
+      expected: [`issue validating page frontmatter: must be object`],
+    },
+    {
+      description: "enum",
+      input: `---
+kind: kind3
+---
+
+This is a page.`,
+      expected: [`issue validating page frontmatter: .kind: must be one of: kind1, kind2, null`],
     },
     {
       description: "no frontmatter",

--- a/server/lint-frontmatter.ts
+++ b/server/lint-frontmatter.ts
@@ -6,26 +6,7 @@ import type { Literal } from "mdast";
 import type { JSONSchema7 } from "json-schema";
 import Ajv from "ajv";
 
-const possibleProducts = [
-  "identity-governance",
-  "identity-security",
-  "mwi",
-  "zero-trust",
-  "platform-wide",
-];
-
-const possibleTypes = [
-  "how-to",
-  "conceptual",
-  "get-started",
-  "reference",
-  "faq",
-  "other",
-];
-
-interface LintFrontmatterOptions {
-  allowedFields: Array<string>;
-}
+const schemaErrorPrefix = "issue validating page frontmatter: ";
 
 export const remarkLintFrontmatter = lintRule(
   "remark-lint:frontmatter",
@@ -37,6 +18,7 @@ export const remarkLintFrontmatter = lintRule(
 
     let hasFrontmatter = false;
     const ajv = new Ajv({
+      // Include all errors and their messages. Critical for printing linter warnings.
       allErrors: true,
     });
     const validate = ajv.compile(options);
@@ -66,30 +48,29 @@ export const remarkLintFrontmatter = lintRule(
         return;
       }
 
-      const extraFields: Array<string> = [];
       validate.errors!.forEach((e) => {
-        switch (e.keyword) {
-          case "type":
-            // Ignore specific type errors for now. The linter focuses on
-            // additional properties and overall malformed frontmatter, so
-            // check whether the whole frontmatter document is an incorrect
-            // type.
-            if (e.instancePath !== "") {
-              return;
-            }
-            vfile.message("page frontmatter must be a YAML object");
-            return;
-
-          case "additionalProperties":
-            extraFields.push(e.params.additionalProperty);
+        let msg = schemaErrorPrefix;
+        if (e.instancePath !== "") {
+          msg += `${e.instancePath.replaceAll("/", ".")}: `;
         }
+        switch (e.keyword) {
+          case "additionalProperties":
+            msg += `unexpected property "${e.params.additionalProperty}"`;
+            break;
+          case "enum":
+            const allowed = e.params.allowedValues.map((v: unknown) => {
+              if (v === null) {
+                return "null";
+              }
+              return v;
+            });
+            msg += `must be one of: ${allowed.join(", ")}`;
+            break;
+          default:
+            msg += e.message!;
+        }
+        vfile.message(msg);
       });
-
-      if (extraFields.length > 0) {
-        vfile.message(
-          `page frontmatter has unrecognized fields: ${extraFields.join(", ")}`,
-        );
-      }
     });
 
     if (!hasFrontmatter) {


### PR DESCRIPTION
This field specifies the kind of guide, e.g., a how-to guide or reference. Since expectations and standards differ across kinds of guides, we can use the `page_type` field to apply branching logic in linters.

To begin with, the field is optional. Once we roll it out across the docs, we can make it mandatory. The field is an enum with the following possible values:

```yaml
- null   # To make it optional while we roll it out
- conceptual
- faq
- how-to # Includes getting started tutorials
- landing
- reference
- troubleshooting
```

This taxonomy includes three parts of the Diataxis model for documentation, with "tutorials" folded into "how-to guides" since our expectations are equivalent for these in the Teleport docs. It also includes kinds that are unique to the Teleport docs: FAQ, landing pages, and troubleshooting. We can modify these categories as we roll out this field

Note that, while there is already a guide type value in the `tags` field, this change proposes a separate `page_type` to make it clear that this is a separate concern. The `tags` field is optional in Docusaurus, and a page does not need to specify its type using this field. This also allows us to separate the possible values of `page_type` from those of the page type tags depending on our linting needs.

This change edits `lint-frontmatter` to include generic JSON Schema validation errors as well as explicit checks for enums, alongside the additional property issues that it handles already.