### PR TITLE
dep: Mark `tokenx` as a non-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rehype-highlight": "^7.0.2",
     "remark-mdx": "^2.1.1",
     "remark-parse": "^10.0.1",
+    "tokenx": "^1.3.0",
     "vite-node": "^6.0.0"
   },
   "devDependencies": {
@@ -118,7 +119,6 @@
     "remark-validate-links": "^11.0.2",
     "storybook": "^8.6.18",
     "to-vfile": "^8.0.0",
-    "tokenx": "^1.3.0",
     "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.7",
     "tsc-esm-fix": "^3.1.0",


### PR DESCRIPTION
Followup for the https://github.com/gravitational/docs-website/pull/651