### PR TITLE
Fix horizontal page overflow on mobile screens

### DIFF
--- a/src/components/Pages/Homepage/DocsHeader/DocsHeader.module.css
+++ b/src/components/Pages/Homepage/DocsHeader/DocsHeader.module.css
@@ -1,10 +1,17 @@
 .docsHeader {
   position: relative;
   z-index: 1;
-  margin-left: -40px;
-  margin-right: -40px;
   margin-top: -16px !important; /* Used to align the DocsHeader with the header which is caused by padding in Docusaurus' container and col classes */
+  margin-left: -16px;
+  margin-right: -16px;
+
   margin-bottom: var(--ifm-paragraph-margin-bottom);
+
+  @media (--md-scr) {
+    margin-left: -40px;
+    margin-right: -40px;
+  }
+
   @media (--lg-scr) {
     margin-bottom: 50px;
   }

--- a/src/components/Pages/Homepage/Integrations/Integrations.module.css
+++ b/src/components/Pages/Homepage/Integrations/Integrations.module.css
@@ -1,11 +1,13 @@
 .integrations {
   padding: var(--m-5) var(--m-5);
   background-color: #fbfbfc;
-  margin-left: -40px;
-  margin-right: -40px;
+  margin-left: -16px;
+  margin-right: -16px;
 
   @media (--md-scr) {
     padding: var(--m-8) var(--m-5);
+    margin-left: -40px;
+    margin-right: -40px;
   }
 
   &.noBackgroundColor {


### PR DESCRIPTION
This PR fixes the unintended horizontal page overflow on mobile screens caused by the negative horizontal margin in `DocsHeader` and `Integrations`.


Changes:
- The negative horizontal margin is set to 16px on mobile in order to match the page padding.