### PR TITLE
Add plugin for IaC alternatives to tctl resources

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "18.x",
-      "branch": "branch/v18",
+      "branch": "paul.gottschling/2026-07-24-resource-converter",
       "isDefault": true
     },
     {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -40,6 +40,7 @@ import { llmsTxtPluginOptions } from "./server/llms";
 import { fetchVideoMeta } from "./server/youtube-meta";
 import { getFromSecretOrEnv } from "./utils/general";
 import addTokenCounts from "./server/llms/add-token-counts";
+import remarkConvertResource from "./server/remark-convert-resource";
 
 const latestVersion = getLatestVersion();
 
@@ -402,6 +403,14 @@ const config: Config = {
             },
           ],
           remarkNoH1,
+          [
+            remarkConvertResource,
+            {
+              binaryPath:
+                "build.assets/tooling/cmd/convert-resource/convert-resource",
+              rootDir: (vfile: VFile) => getRootDir(vfile),
+            },
+          ],
           [
             remarkCodeSnippet,
             {

--- a/scripts/download-content-archive.sh
+++ b/scripts/download-content-archive.sh
@@ -61,6 +61,24 @@ curl -sS -L --fail \
 # Detect tar flavor and add --wildcards only for GNU tar
 TAR_VERSION_STR="$(tar --version 2>&1 | head -n1 || true)"
 TAR_ARGS=(-xf "${BRANCH_TAR_FILE}" --strip-components=1 -C "$1")
+TAR_PATHS=(
+    # Docs pages and images
+    '*/docs'
+    # Files included by docs pages as partials
+    '*/examples'
+    '*/skills'
+    '*/CHANGELOG.md'
+    # Tooling that accesses the Teleport source. The build.assets/tooling module
+    # relies on api and lib in the root gravitational/teleport module.
+    '*/build.assets/tooling'
+    '*/*.go'
+    '*/go.mod'
+    '*/go.sum'
+    '*/api'
+    '*/lib'
+    '*/session'
+)
+
 if echo "${TAR_VERSION_STR}" | grep -qi 'gnu tar'; then
     TAR_ARGS+=(--wildcards)
 fi
@@ -69,6 +87,6 @@ tree -D -h "${DOWNLOADS_DIR}"
 
 # Extract desired paths
 echo "Extracting selected content from ${BRANCH_TAR_FILE} to $1"
-tar "${TAR_ARGS[@]}" '*/docs' '*/examples' '*/skills' '*/CHANGELOG.md'
+tar "${TAR_ARGS[@]}" "${TAR_PATHS[@]}"
 
 tree -L 1 "$1"

--- a/scripts/prepare-files.mts
+++ b/scripts/prepare-files.mts
@@ -1,8 +1,9 @@
 import { importDirectorySync } from '@iconify/tools';
 import {  writeFileSync, copyFileSync, rmSync, existsSync, mkdirSync, readFileSync } from "fs";
-import { join, resolve, dirname } from "path";
+import { isAbsolute, join, resolve, dirname } from "path";
 import { glob } from "glob";
 import { parseSkillMarkdown } from "../server/parse-skill-md";
+import { spawn } from "child_process";
 import {
   getCurrentVersion,
   getLatestVersion,
@@ -75,6 +76,53 @@ versions.forEach((version) => {
 });
 
 writeVersions();
+
+const buildResourceExampleConvert = (version: string): Promise<void> => {
+  const convertResourceDir = join(
+    "content",
+    version,
+    "build.assets",
+    "tooling",
+    "cmd",
+    "convert-resource",
+  );
+  return new Promise((resolve, reject) => {
+    if (!existsSync(convertResourceDir)) {
+      console.warn(
+        `convert-resource project not found at ${convertResourceDir}. Skipping build.`,
+      );
+      return resolve();
+    }
+
+    // If we are on AWS Amplify, we may be caching the Go installation directory
+    // and GOPATH value. The Amplify build configuration requires placing
+    // these in a directory local to the project with a relative path.
+    // Assemble absolute paths for these values.
+    const goBinary = process.env.GO_INSTALL_DIR
+      ? join(process.cwd(), process.env.GO_INSTALL_DIR, "go", "bin", "go")
+      : "go";
+    const goPath =
+      process.env.GOPATH && isAbsolute(process.env.GOPATH)
+        ? process.env.GOPATH
+        : join(process.cwd(), process.env.GOPATH);
+    const proc = spawn(goBinary, ["build", "."], {
+      cwd: convertResourceDir,
+      stdio: "inherit",
+      env: { ...process.env, GOPATH: goPath },
+    });
+    proc.on("close", (code) =>
+      code === 0
+        ? resolve()
+        : reject(
+            new Error(
+              `convert-resource build failed for ${version} (exit ${code})`,
+            ),
+          ),
+    );
+  });
+};
+
+await Promise.all(versions.map(buildResourceExampleConvert));
 
 // Make sure the upcoming releases page is the same on all 3 branches.
 const versionsToOverride = getVersionNames().filter(

--- a/scripts/prepare-files.mts
+++ b/scripts/prepare-files.mts
@@ -1,6 +1,6 @@
 import { importDirectorySync } from '@iconify/tools';
 import {  writeFileSync, copyFileSync, rmSync, existsSync, mkdirSync, readFileSync } from "fs";
-import { isAbsolute, join, resolve, dirname } from "path";
+import { join, resolve, dirname } from "path";
 import { glob } from "glob";
 import { parseSkillMarkdown } from "../server/parse-skill-md";
 import { spawn } from "child_process";
@@ -94,21 +94,13 @@ const buildResourceExampleConvert = (version: string): Promise<void> => {
       return resolve();
     }
 
-    // If we are on AWS Amplify, we may be caching the Go installation directory
-    // and GOPATH value. The Amplify build configuration requires placing
-    // these in a directory local to the project with a relative path.
-    // Assemble absolute paths for these values.
     const goBinary = process.env.GO_INSTALL_DIR
-      ? join(process.cwd(), process.env.GO_INSTALL_DIR, "go", "bin", "go")
+      ? join(process.env.GO_INSTALL_DIR, "go", "bin", "go")
       : "go";
-    const goPath =
-      process.env.GOPATH && isAbsolute(process.env.GOPATH)
-        ? process.env.GOPATH
-        : join(process.cwd(), process.env.GOPATH);
     const proc = spawn(goBinary, ["build", "."], {
       cwd: convertResourceDir,
       stdio: "inherit",
-      env: { ...process.env, GOPATH: goPath },
+      env: process.env,
     });
     proc.on("close", (code) =>
       code === 0

--- a/server/remark-convert-resource.test.ts
+++ b/server/remark-convert-resource.test.ts
@@ -1,0 +1,169 @@
+import { jest, beforeEach, describe, expect, test } from "@jest/globals";
+import remarkConvertResource from "../server/remark-convert-resource";
+import { VFile, VFileOptions } from "vfile";
+import { remark } from "remark";
+import mdx from "remark-mdx";
+import { spawnSync } from "child_process";
+
+const mockedSpawnSync = jest.fn();
+
+const transformer = (
+  options: VFileOptions,
+  mockedSpawnSync: typeof spawnSync,
+) =>
+  remark()
+    .use(mdx as any)
+    .use(remarkConvertResource as any, {
+      // Not used, since we mock child_process.
+      binaryPath: "./converter",
+      spawner: mockedSpawnSync,
+    })
+    .processSync(new VFile(options) as any);
+
+describe("server/remark-convert-resource", () => {
+  interface testCase {
+    description: string;
+    input: string;
+    binaryStatusHCL: number;
+    binaryOutputHCL: string;
+    binaryStatusKube: number;
+    binaryOutputKube: string;
+    expected: string;
+  }
+
+  beforeEach(() => {
+    mockedSpawnSync.mockReset();
+  });
+
+  const testCases: testCase[] = [
+    {
+      description: "hcl and kubernetes conversions",
+      input: `\`\`\`teleport-resource
+tctl yaml
+\`\`\`
+`,
+      binaryStatusHCL: 0,
+      binaryOutputHCL: "sample hcl",
+      binaryStatusKube: 0,
+      binaryOutputKube: "kube yaml",
+      expected: `<Tabs>
+  <TabItem label="tctl">
+    \`\`\`yaml
+    tctl yaml
+    \`\`\`
+  </TabItem>
+
+  <TabItem label="Terraform provider">
+    \`\`\`hcl
+    sample hcl
+    \`\`\`
+  </TabItem>
+
+  <TabItem label="Kubernetes operator">
+    \`\`\`yaml
+    kube yaml
+    \`\`\`
+  </TabItem>
+</Tabs>
+`,
+    },
+    {
+      description: "kubernetes conversion",
+      input: `\`\`\`teleport-resource
+tctl yaml
+\`\`\`
+`,
+      binaryStatusHCL: 2,
+      binaryOutputHCL: "",
+      binaryStatusKube: 0,
+      binaryOutputKube: "kube yaml",
+      expected: `<Tabs>
+  <TabItem label="tctl">
+    \`\`\`yaml
+    tctl yaml
+    \`\`\`
+  </TabItem>
+
+  <TabItem label="Kubernetes operator">
+    \`\`\`yaml
+    kube yaml
+    \`\`\`
+  </TabItem>
+</Tabs>
+`,
+    },
+    {
+      description: "hcl conversion",
+      input: `\`\`\`teleport-resource
+tctl yaml
+\`\`\`
+`,
+      binaryStatusHCL: 0,
+      binaryOutputHCL: "sample hcl",
+      binaryStatusKube: 2,
+      binaryOutputKube: "",
+      expected: `<Tabs>
+  <TabItem label="tctl">
+    \`\`\`yaml
+    tctl yaml
+    \`\`\`
+  </TabItem>
+
+  <TabItem label="Terraform provider">
+    \`\`\`hcl
+    sample hcl
+    \`\`\`
+  </TabItem>
+</Tabs>
+`,
+    },
+    {
+      description: "no conversions",
+      input: `\`\`\`teleport-resource
+tctl yaml
+\`\`\`
+`,
+      binaryStatusHCL: 2,
+      binaryOutputHCL: "",
+      binaryStatusKube: 2,
+      binaryOutputKube: "",
+      expected: `\`\`\`yaml
+tctl yaml
+\`\`\`
+`,
+    },
+  ];
+
+  test.each(testCases)("$description", (testCase) => {
+    // Configure the HCL conversion, which we expect to happen
+    // before the Kubernetes conversion, then configure the Kubernetes
+    // conversion. We need to do this in the correct order since
+    // mockReturnValueOnce pushes to a queue of mock configurations.
+    mockedSpawnSync.mockReturnValueOnce({
+      stdout: testCase.binaryOutputHCL,
+      status: testCase.binaryStatusHCL,
+      pid: 111,
+      output: [testCase.binaryOutputHCL],
+      signal: null,
+      stderr: "",
+    });
+
+    mockedSpawnSync.mockReturnValueOnce({
+      stdout: testCase.binaryOutputKube,
+      status: testCase.binaryStatusKube,
+      pid: 111,
+      output: [testCase.binaryOutputKube],
+      signal: null,
+      stderr: "",
+    });
+
+    const result = transformer(
+      {
+        value: testCase.input,
+      },
+      mockedSpawnSync,
+    ).toString();
+
+    expect(result).toEqual(testCase.expected);
+  });
+});

--- a/server/remark-convert-resource.ts
+++ b/server/remark-convert-resource.ts
@@ -1,0 +1,158 @@
+import type { Code as MdastCode, Root } from "mdast";
+import type { Transformer } from "unified";
+import { visit, SKIP } from "unist-util-visit";
+import { VFile } from "vfile";
+import type { Node, Parent } from "unist";
+import { spawnSync } from "child_process";
+import { join } from "path";
+import type { MdxJsxAttribute, MdxAnyElement } from "./types-unist";
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+
+// isTeleportResource indicates whether the node is a code fence with the
+// "teleport-resource" label.
+const isTeleportResource = (node: Node): node is MdastCode =>
+  node.type === "code" && (node as MdastCode).lang === "teleport-resource";
+
+// RemarkConvertResourceOptions contains options for the remarkConvertResource
+// plugin.
+interface RemarkConvertResourceOptions {
+  // The path to the conversion binary relative to rootDir. The binary must take
+  // a tctl resource in stdin and use the "-format" flag to determine whether
+  // to output an HCL configuration or Kubernetes manifest, which it prints to
+  // stdout. An error code of 2 indicates that the resource is not supported
+  // for a given infrastructure as code tool.
+  binaryPath: string;
+  // spawner is an implementation of spawnSync. By default, we use the one from
+  // the child_process stdlib package.
+  spawner?: typeof spawnSync;
+  // rootDir is the directory in which to find binaryPath. This can be a
+  // function to, for example, extract the rootDir from the version of a docs
+  // page.
+  rootDir?: string | ((vfile: VFile) => string);
+}
+
+// CodeTabConfig is the information we need to construct a TabItem from a code
+// fence.
+interface CodeTabConfig {
+  // label is the label to apply to the rendered code snippet, e.g., "hcl" or
+  // "yaml"
+  label: string;
+  // code is the AST representation of the code snippet to render
+  code: MdastCode;
+}
+
+// tabsForCodeBlocks returns an AST representation of a Tabs component in which
+// each TabItem contains a Teleport resource as configured for a specific
+// infrastructure as code tool.
+function tabsForCodeBlocks(blocks: CodeTabConfig[]): Node {
+  const tabs = {
+    type: "mdxJsxFlowElement",
+    name: "Tabs",
+    attributes: [],
+    children: [] as MdxJsxFlowElement[],
+  };
+
+  blocks.forEach((b: CodeTabConfig) => {
+    tabs.children.push({
+      name: "TabItem",
+      type: "mdxJsxFlowElement",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "label",
+          value: b.label,
+        },
+      ],
+      children: [b.code],
+    });
+  });
+
+  return tabs;
+}
+
+// remarkConvertResource is a plugin that finds code snippets with the
+// "teleport-resource" label and replaces them with Tabs components that contain
+// one TabItem for each variation of that resource supported by an
+// infrastructure as code tool. If only tctl supports a resource, the plugin
+// replaces the "teleport-resource" label with a "yaml" label.
+export default function remarkConvertResource({
+  binaryPath,
+  spawner = spawnSync,
+  rootDir = "",
+}: RemarkConvertResourceOptions): Transformer<Root> {
+  return (root: Node, vfile: VFile) => {
+    const resolvedRoot = typeof rootDir == "string" ? rootDir : rootDir(vfile);
+
+    visit(
+      root,
+      isTeleportResource,
+      (node: MdastCode, index, parent: Parent) => {
+        if (index === undefined) {
+          return;
+        }
+        const fullPath = join(resolvedRoot, binaryPath);
+        const hclResult = spawner(fullPath, [`-format=hcl`], {
+          input: node.value,
+        });
+
+        if ((hclResult.error as NodeJS.ErrnoException)?.code === "ENOENT") {
+          throw new Error(
+            `convert-resource binary not found at ${fullPath}. Navigate to ${resolvedRoot} and run "go build .".`,
+          );
+        }
+
+        if (hclResult.status === 1) {
+          throw new Error(`problem converting to HCL: ${hclResult.stderr}`);
+        }
+
+        const kubeResult = spawner(fullPath, [`-format=kube`], {
+          input: node.value,
+        });
+        if (kubeResult.status === 1) {
+          throw new Error(
+            `problem converting to Kubernetes YAML: ${kubeResult.stderr}`,
+          );
+        }
+
+        // It is not possible to convert this YAML tctl resource, so treat it as
+        // a regular YAML code snippet.
+        if (hclResult.status === 2 && kubeResult.status === 2) {
+          (parent.children[index] as MdastCode).lang = "yaml";
+          return;
+        }
+
+        const tabs: CodeTabConfig[] = [];
+        tabs.push({
+          label: "tctl",
+          code: {
+            type: "code",
+            lang: "yaml",
+            value: node.value,
+          },
+        });
+        if (hclResult.status === 0) {
+          tabs.push({
+            label: "Terraform provider",
+            code: {
+              type: "code",
+              lang: "hcl",
+              value: hclResult.stdout.toString(),
+            },
+          });
+        }
+        if (kubeResult.status === 0) {
+          tabs.push({
+            label: "Kubernetes operator",
+            code: {
+              type: "code",
+              lang: "yaml",
+              value: kubeResult.stdout.toString(),
+            },
+          });
+        }
+        parent.children[index] = tabsForCodeBlocks(tabs);
+        return [SKIP, index + 1];
+      },
+    );
+  };
+}


### PR DESCRIPTION
The plugin transforms any code fence with the `teleport-resource` label into a `Tabs` component with separate tabs for `tctl`, the Teleport operator, and the Teleport Terraform provider. It shells out to the script added in gravitational/teleport#67528 to perform the conversion.