### PR TITLE
Group storybook dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,10 @@ updates:
       inkeep:
         patterns:
           - "@inkeep/*"
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"
       postcss:
         patterns:
           - "*postcss*"


### PR DESCRIPTION
Add Storybook-related deps to a dedicated group in the dependabot config. This addresses situations like the one presented by #691, which completes a major upgrade of `@storybook/react-webpack5` without upgrading any peer dependencies. This happens because Storybook-related dependencies fall through to the `npm-web-dependencies` group. But because major upgrades aren't part of the group, a major Storybook upgrade becomes its own PR.