### PR TITLE
docs: add CLAUDE.md and import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
An AGENTS.md file was created in a [past PR](https://github.com/gravitational/docs-website/pull/648) to provide docs context to contributor agents. However, Claude does not pick this up as it looks specifically for a CLAUDE.md. According to [these docs](https://code.claude.com/docs/en/memory#agents-md ), we can now use an @AGENTS.md import in the CLAUDE.md file to tell Claude to use the AGENTS.md file. This PR adds the CLAUDE.md file and the import line.