### PR TITLE
Add error handling for YouTube API failures

### DIFF
--- a/server/youtube-meta.ts
+++ b/server/youtube-meta.ts
@@ -145,8 +145,17 @@ export async function fetchVideoMeta(id: string): Promise<Meta> {
         `${YOUTUBE_API_URL}/${REQUEST_PATH}?part=snippet&part=contentDetails&id=${id}&key=${YOUTUBE_API_KEY}`
       );
 
+      if (!response.ok) {
+        throw new Error(
+          `Error in YouTube API request for video ID ${id}: ${response.status} ${response.statusText}`,
+        );
+      }
+
       const rawData: unknown = await response.json();
-      const rawDataItem = (rawData as RawVideoMeta).items[0];
+      const rawDataItem = (rawData as RawVideoMeta).items?.[0];
+      if (!rawDataItem) {
+        throw new Error(`YouTube API: No items found for video ID ${id}`);
+      }
 
       data = {
         href: data.href,


### PR DESCRIPTION
Rather than letting the code read an out-of-bounds index from the API response, explicitly handle non-2xx response codes and response payloads with no video items. This lets us take action on YouTube API failures more easily.