### PR TITLE
Enforce type in enterprise frontmatter field

### DIFF
--- a/frontmatter_fields.yaml
+++ b/frontmatter_fields.yaml
@@ -63,8 +63,12 @@ properties:
   sidebar_custom_props:
     type: object
 
-  # The fields below are used in custom components and linters
-  enterprise: {}
+  # The fields below are used in custom components and linters.
+  #
+  # enterprise is the name of a Teleport Enterprise feature that the current
+  # docs page pertains to. Used to populate text in page components.
+  enterprise:
+    type: string
   page_type:
     enum:
       # Make page_type an optional frontmatter field until we can roll it out


### PR DESCRIPTION
Because of the name of the field (which implies an "is"), there is a temptation to assign it to a Boolean value. This change enforces a string value so the frontmatter linter can reject Boolean values.