### PR TITLE
Add the SkillsBanner component

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,5 +1,6 @@
 .modal {
   position: fixed;
+  visibility: visible;
   left: 0;
   top: 0;
   width: 100%;

--- a/src/components/PageActions/Dropdown.tsx
+++ b/src/components/PageActions/Dropdown.tsx
@@ -57,6 +57,7 @@ const DropdownItem: React.FC<DrodownItemProps> = ({
             if (type === "button" && onClick) {
               onClick();
             } else if (type === "modal") {
+              e.stopPropagation();
               onClick?.();
               setModalActive(true);
             }

--- a/src/components/SkillsBanner/SkillsBanner.module.css
+++ b/src/components/SkillsBanner/SkillsBanner.module.css
@@ -19,6 +19,7 @@
   background-color: var(--color-interactive-tonal-success-0);
   color: var(--color-interactive-success-default);
   border-color: var(--color-interactive-success-default);
+  margin-left: 0;
 
   svg {
     path {

--- a/src/components/SkillsBanner/SkillsBanner.module.css
+++ b/src/components/SkillsBanner/SkillsBanner.module.css
@@ -1,0 +1,70 @@
+.skillsBanner {
+  padding: var(--m-2);
+  background-color: var(--color-background-depth-2);
+  border-radius: var(--m-1-5);
+  border: 1px solid var(--color-tonal-neutral-0);
+  display: flex;
+  flex-direction: column;
+  gap: var(--m-2);
+  align-items: flex-start;
+  margin-bottom: var(--m-2);
+
+  @media (--md-scr) {
+    padding: var(--m-2) var(--m-3);
+    margin-bottom: var(--m-3);
+  }
+}
+
+.skillBadge {
+  background-color: var(--color-interactive-tonal-success-0);
+  color: var(--color-interactive-success-default);
+  border-color: var(--color-interactive-success-default);
+
+  svg {
+    path {
+      fill: var(--color-interactive-success-default);
+    }
+  }
+}
+
+.title {
+  font-size: var(--fs-text-xl);
+  margin-bottom: var(--m-0-5);
+}
+
+.description {
+  font-size: var(--fs-text-lg);
+  p {
+    margin-bottom: unset;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: var(--m-1);
+
+  .button {
+    font-size: var(--fs-text-sm);
+    display: flex;
+    align-items: center;
+    gap: var(--m-1);
+
+    &:last-child {
+      color: var(--color-foreground-muted);
+
+      svg {
+        path {
+          fill: var(--color-foreground-muted);
+        }
+      }
+      &:hover {
+        color: var(--color-white);
+        svg {
+          path {
+            fill: var(--color-white);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/SkillsBanner/SkillsBanner.stories.tsx
+++ b/src/components/SkillsBanner/SkillsBanner.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import { userEvent, within, expect } from "storybook/test";
+import SkillsBanner from "./SkillsBanner";
+import ExclusivityContext from "../ExclusivityBanner/context";
+import { collectEvents } from "@site/src/utils/analytics";
+import skills from "@site/data/skills.json";
+
+const meta: Meta<typeof SkillsBanner> = {
+  title: "components/SkillsBanner",
+  component: SkillsBanner,
+};
+
+export default meta;
+type Story = StoryObj<typeof SkillsBanner>;
+
+const skill = skills[0];
+
+export const NoSkills: Story = {
+  render: () => (
+    <ExclusivityContext.Provider value={{ skillsForPage: [] }}>
+      <SkillsBanner emitEvent={collectEvents()} />
+    </ExclusivityContext.Provider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Banner is not rendered when there are no skills", async () => {
+      expect(canvas.queryByText("Skill Available")).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const WithSkill: Story = {
+  render: () => (
+    <ExclusivityContext.Provider value={{ skillsForPage: [skill] }}>
+      <SkillsBanner emitEvent={collectEvents()} />
+    </ExclusivityContext.Provider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Banner shows skill badge and readable name", async () => {
+      expect(canvas.getByText("Skill Available")).toBeInTheDocument();
+      expect(canvas.getByText(skill.readableName)).toBeInTheDocument();
+    });
+
+    await step(
+      "Install Skill and View Raw Skill buttons are present",
+      async () => {
+        expect(
+          canvas.getByRole("button", { name: "Install Skill" }),
+        ).toBeInTheDocument();
+        expect(
+          canvas.getByRole("link", { name: /view raw skill/i }),
+        ).toBeInTheDocument();
+      },
+    );
+  },
+};
+
+export const InstallButtonOpensModal: Story = {
+  render: () => (
+    <ExclusivityContext.Provider value={{ skillsForPage: [skill] }}>
+      <SkillsBanner emitEvent={collectEvents()} />
+    </ExclusivityContext.Provider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click Install Skill button", async () => {
+      await userEvent.click(
+        canvas.getByRole("button", { name: "Install Skill" }),
+      );
+    });
+
+    await step("Modal shows skill name and install command", async () => {
+      expect(
+        canvas.getByText(`Install ${skill.readableName}`),
+      ).toBeInTheDocument();
+      expect(canvas.getByText(skill.installCommand)).toBeInTheDocument();
+    });
+
+    await step("The 'skill_install_clicked' event is fired", async () => {
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "skill_install_clicked",
+        skill_name: skill.name,
+      });
+    });
+  },
+};
+
+export const ModalOpenAndClose: Story = {
+  render: () => (
+    <ExclusivityContext.Provider value={{ skillsForPage: [skill] }}>
+      <SkillsBanner emitEvent={collectEvents()} />
+    </ExclusivityContext.Provider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Open modal", async () => {
+      await userEvent.click(
+        canvas.getByRole("button", { name: "Install Skill" }),
+      );
+      expect(
+        canvas.getByText(`Install ${skill.readableName}`),
+      ).toBeInTheDocument();
+    });
+
+    await step("Close modal", async () => {
+      const closeButton = canvasElement.querySelector(
+        '[class*="closeButton"]',
+      ) as HTMLElement;
+      await userEvent.click(closeButton);
+      expect(
+        canvas.queryByText(`Install ${skill.readableName}`),
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const ViewRawSkill: Story = {
+  render: () => (
+    <ExclusivityContext.Provider value={{ skillsForPage: [skill] }}>
+      <SkillsBanner emitEvent={collectEvents()} />
+    </ExclusivityContext.Provider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Click the 'View Raw Skill' link", async () => {
+      await userEvent.click(
+        canvas.getByRole("link", { name: /view raw skill/i }),
+      );
+    });
+
+    await step("The view_raw_skill_clicked event is fired", async () => {
+      expect(window.events).toHaveLength(1);
+      expect(window.events[0]).toEqual({
+        event: "view_raw_skill_clicked",
+        skill_name: skill.name,
+      });
+    });
+  },
+};

--- a/src/components/SkillsBanner/SkillsBanner.stories.tsx
+++ b/src/components/SkillsBanner/SkillsBanner.stories.tsx
@@ -48,10 +48,14 @@ export const WithSkill: Story = {
       "Install Skill and View Raw Skill buttons are present",
       async () => {
         expect(
-          canvas.getByRole("button", { name: "Install Skill" }),
+          canvas.getByRole("button", {
+            name: `Install the ${skill.readableName} skill`,
+          }),
         ).toBeInTheDocument();
         expect(
-          canvas.getByRole("link", { name: /view raw skill/i }),
+          canvas.getByRole("link", {
+            name: `View the raw ${skill.readableName} skill`,
+          }),
         ).toBeInTheDocument();
       },
     );
@@ -69,7 +73,9 @@ export const InstallButtonOpensModal: Story = {
 
     await step("Click Install Skill button", async () => {
       await userEvent.click(
-        canvas.getByRole("button", { name: "Install Skill" }),
+        canvas.getByRole("button", {
+          name: `Install the ${skill.readableName} skill`,
+        }),
       );
     });
 
@@ -101,7 +107,9 @@ export const ModalOpenAndClose: Story = {
 
     await step("Open modal", async () => {
       await userEvent.click(
-        canvas.getByRole("button", { name: "Install Skill" }),
+        canvas.getByRole("button", {
+          name: `Install the ${skill.readableName} skill`,
+        }),
       );
       expect(
         canvas.getByText(`Install ${skill.readableName}`),
@@ -114,7 +122,7 @@ export const ModalOpenAndClose: Story = {
       ) as HTMLElement;
       await userEvent.click(closeButton);
       expect(
-        canvas.queryByText(`Install ${skill.readableName}`),
+        canvas.queryByText(`Install the ${skill.readableName} skill`),
       ).not.toBeInTheDocument();
     });
   },
@@ -131,7 +139,9 @@ export const ViewRawSkill: Story = {
 
     await step("Click the 'View Raw Skill' link", async () => {
       await userEvent.click(
-        canvas.getByRole("link", { name: /view raw skill/i }),
+        canvas.getByRole("link", {
+          name: `View the raw ${skill.readableName} skill`,
+        }),
       );
     });
 

--- a/src/components/SkillsBanner/SkillsBanner.tsx
+++ b/src/components/SkillsBanner/SkillsBanner.tsx
@@ -1,0 +1,91 @@
+import { useContext, useState } from "react";
+import cn from "clsx";
+import ExclusivityContext from "../ExclusivityBanner/context";
+import Icon from "../Icon";
+import styles from "./SkillsBanner.module.css";
+import Button from "../Button";
+import { Modal } from "../Modal";
+import Pre from "@site/src/theme/MDXComponents/Pre";
+import { trackEvent } from "@site/src/utils/analytics";
+
+const SkillsBanner: React.FC<{
+  emitEvent?: (name: string, params: any) => void;
+}> = ({ emitEvent }) => {
+  const [modalActive, setModalActive] = useState<string | null>(null);
+  const exclusivityContext = useContext(ExclusivityContext);
+  const skillsForPage = exclusivityContext?.skillsForPage ?? [];
+
+  if (skillsForPage.length === 0) {
+    return null;
+  }
+
+  return skillsForPage.map((skill) => (
+    <div key={skill.name} className={styles.skillsBanner}>
+      <span className={cn(styles.skillBadge, "skillBadge")}>
+        <Icon name="lightbulb" size="sm" /> Skill Available
+      </span>
+      <div>
+        <h2 className={styles.title}>{skill.readableName}</h2>
+        {/*
+        we use dangerouslySetInnerHTML here because the description may contain elements
+        such as inline code that we want to render as HTML. We trust the source of this
+        content, which is the SKILL.md files found in the /skills folder of the Teleport
+        repository.      
+      */}
+        <div
+          className={styles.description}
+          dangerouslySetInnerHTML={{ __html: skill.description }}
+        />
+      </div>
+      <div className={styles.actions}>
+        <Button
+          as="button"
+          className={styles.button}
+          variant="primary"
+          onClick={(e) => {
+            e.stopPropagation();
+            setModalActive(skill.name);
+            trackEvent({
+              event_name: "skill_install_clicked",
+              custom_parameters: {
+                skill_name: skill.name,
+              },
+              emitEvent: emitEvent,
+            });
+          }}
+        >
+          Install Skill
+        </Button>
+        <Button
+          as="link"
+          className={styles.button}
+          variant="borderless"
+          href={skill.rawSourceUrl}
+          target="_blank"
+          onClick={() => {
+            trackEvent({
+              event_name: "view_raw_skill_clicked",
+              custom_parameters: {
+                skill_name: skill.name,
+              },
+              emitEvent: emitEvent,
+            });
+          }}
+        >
+          View Raw Skill <Icon name="arrowSquareOut" size="sm" />
+        </Button>
+        {modalActive === skill.name && (
+          <Modal onClose={() => setModalActive(null)}>
+            <h3>Install {skill.readableName}</h3>
+            <div dangerouslySetInnerHTML={{ __html: skill.description }} />
+            <Pre>
+              <div className="hljs">{skill.installCommand}</div>
+            </Pre>
+          </Modal>
+        )}
+      </div>
+    </div>
+  ));
+};
+
+export default SkillsBanner;

--- a/src/components/SkillsBanner/SkillsBanner.tsx
+++ b/src/components/SkillsBanner/SkillsBanner.tsx
@@ -42,7 +42,7 @@ const SkillsBanner: React.FC<{
           as="button"
           className={styles.button}
           variant="primary"
-          aria-label={`Install skill ${skill.readableName}`}
+          aria-label={`Install the ${skill.readableName} skill`}
           onClick={(e) => {
             e.stopPropagation();
             setModalActive(skill.name);
@@ -63,7 +63,7 @@ const SkillsBanner: React.FC<{
           variant="borderless"
           href={skill.rawSourceUrl}
           target="_blank"
-          aria-label={`View raw skill ${skill.readableName}`}
+          aria-label={`View the raw ${skill.readableName} skill`}
           onClick={() => {
             trackEvent({
               event_name: "view_raw_skill_clicked",

--- a/src/components/SkillsBanner/SkillsBanner.tsx
+++ b/src/components/SkillsBanner/SkillsBanner.tsx
@@ -42,6 +42,7 @@ const SkillsBanner: React.FC<{
           as="button"
           className={styles.button}
           variant="primary"
+          aria-label={`Install skill ${skill.readableName}`}
           onClick={(e) => {
             e.stopPropagation();
             setModalActive(skill.name);
@@ -62,6 +63,7 @@ const SkillsBanner: React.FC<{
           variant="borderless"
           href={skill.rawSourceUrl}
           target="_blank"
+          aria-label={`View raw skill ${skill.readableName}`}
           onClick={() => {
             trackEvent({
               event_name: "view_raw_skill_clicked",

--- a/src/components/SkillsBanner/index.ts
+++ b/src/components/SkillsBanner/index.ts
@@ -1,0 +1,1 @@
+export { default as SkillsBanner } from "./SkillsBanner";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,3 +211,26 @@ svg g.architecture-edges {
   background-size: 20px 20px;
   background-position: center;
 }
+
+.skillBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--m-0-5);
+  padding: var(--m-0-5) var(--m-1-5);
+  border-radius: var(--r-md);
+  background-color: var(--color-interactive-tonal-primary-0);
+  color: var(--color-dark-purple);
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fw-bold);
+  margin-left: var(--m-2);
+  border: 1px solid var(--color-dark-purple);
+  white-space: nowrap;
+  vertical-align: middle;
+
+  svg {
+    path {
+      fill: var(--color-dark-purple);
+    }
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,26 +211,3 @@ svg g.architecture-edges {
   background-size: 20px 20px;
   background-position: center;
 }
-
-.skillBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--m-0-5);
-  padding: var(--m-0-5) var(--m-1-5);
-  border-radius: var(--r-md);
-  background-color: var(--color-interactive-tonal-primary-0);
-  color: var(--color-dark-purple);
-  font-size: var(--fs-text-sm);
-  font-weight: var(--fw-bold);
-  margin-left: var(--m-2);
-  border: 1px solid var(--color-dark-purple);
-  white-space: nowrap;
-  vertical-align: middle;
-
-  svg {
-    path {
-      fill: var(--color-dark-purple);
-    }
-  }
-}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -10,9 +10,11 @@ import Heading from "@theme/Heading";
 import MDXContent from "@theme/MDXContent";
 import clsx from "clsx";
 import { JSX, useContext, useState, type ReactNode } from "react";
+import Icon from "@site/src/components/Icon";
 
-interface DocFrontMatter {
+export interface DocFrontMatter {
   videoBanner: VideoBarProps;
+  skills?: string[];
 }
 
 /**
@@ -40,15 +42,22 @@ export function DocHeader({ className }: { className?: string }): JSX.Element {
   const { hideTitleSection, showDescription } = useDocTemplate();
   const { frontMatter } = useDoc();
   const { pathname } = useLocation();
+  const exclusive = useContext(ExclusivityContext);
 
   const { videoBanner } = frontMatter as DocFrontMatter;
 
   return (
     <header
-      className={clsx({"hide-title-section": hideTitleSection}, className)}
+      className={clsx({ "hide-title-section": hideTitleSection }, className)}
     >
       <Heading as="h1" className="docItemTitle">
         {syntheticTitle}
+        {(exclusive?.skillsForPage ?? []).length > 0 && (
+          <span className="skillBadge" aria-hidden="true">
+            <Icon name="lightbulb" size="sm" /> Skill
+            {(exclusive?.skillsForPage ?? []).length > 1 ? "s" : ""} Available
+          </span>
+        )}
       </Heading>
       {frontMatter.description && showDescription && (
         <p className="docItemDescription">{frontMatter.description}</p>
@@ -56,7 +65,7 @@ export function DocHeader({ className }: { className?: string }): JSX.Element {
       <PageActions pathname={pathname} />
       {videoBanner && <VideoBar {...videoBanner} />}
     </header>
-  )
+  );
 }
   
 

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -10,11 +10,9 @@ import Heading from "@theme/Heading";
 import MDXContent from "@theme/MDXContent";
 import clsx from "clsx";
 import { JSX, useContext, useState, type ReactNode } from "react";
-import Icon from "@site/src/components/Icon";
 
-export interface DocFrontMatter {
+interface DocFrontMatter {
   videoBanner: VideoBarProps;
-  skills?: string[];
 }
 
 /**
@@ -42,22 +40,15 @@ export function DocHeader({ className }: { className?: string }): JSX.Element {
   const { hideTitleSection, showDescription } = useDocTemplate();
   const { frontMatter } = useDoc();
   const { pathname } = useLocation();
-  const exclusive = useContext(ExclusivityContext);
 
   const { videoBanner } = frontMatter as DocFrontMatter;
 
   return (
     <header
-      className={clsx({ "hide-title-section": hideTitleSection }, className)}
+      className={clsx({"hide-title-section": hideTitleSection}, className)}
     >
       <Heading as="h1" className="docItemTitle">
         {syntheticTitle}
-        {(exclusive?.skillsForPage ?? []).length > 0 && (
-          <span className="skillBadge" aria-hidden="true">
-            <Icon name="lightbulb" size="sm" /> Skill
-            {(exclusive?.skillsForPage ?? []).length > 1 ? "s" : ""} Available
-          </span>
-        )}
       </Heading>
       {frontMatter.description && showDescription && (
         <p className="docItemDescription">{frontMatter.description}</p>
@@ -65,7 +56,7 @@ export function DocHeader({ className }: { className?: string }): JSX.Element {
       <PageActions pathname={pathname} />
       {videoBanner && <VideoBar {...videoBanner} />}
     </header>
-  );
+  )
 }
   
 

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -31,6 +31,7 @@ import EnterpriseFeatureWidget from "@site/src/components/EnterpriseFeatureWidge
 import Callout from "@site/src/components/Callout";
 import FAQSection from "@site/src/components/FAQSection";
 import SkillsTable from "@site/src/components/SkillsTable/SkillsTable";
+import SkillsBanner from "@site/src/components/SkillsBanner/SkillsBanner";
 
 const MDXComponents: MDXComponentsObject = {
   ...OriginalMDXComponents,
@@ -73,6 +74,7 @@ const MDXComponents: MDXComponentsObject = {
   Callout,
   FAQSection,
   SkillsTable,
+  SkillsBanner,
 };
 
 export default MDXComponents;


### PR DESCRIPTION
This PR adds a new `SkillsBanner` component based on [the Figma design](https://www.figma.com/design/bgdYxWeIHqfwOGM0K6WT8b/Skills?node-id=246-15446&m=dev). It highlights agent skills that have been associated with the specific documentation page using the `skills` field in the frontmatter.

This is a stacked PR on top of #728, as the changes are partly dependent on the changes presented in the feature branch.

## Changes
- Add the `SkillsBanner` component.

  Example usage in MDX:

  ```
  ---
  title: Example page
  description: This page demonstrates the usage of SkillsBanner
  skills:
    - a-name-of-a-teleport-skill
  ---

  Lorem ipsum dolor sit amet.

  <SkillsBanner />
  ```
   Note that the banner component is rendered for each skill listed in the `skills` frontmatter field if a matching skill is found in the `data/skills.json` file.
- Add Storybook interaction tests for the `SkillsBanner` component.
- Add a `Skill available` badge on the side of the page title in `src/theme/DocItem/Content/index.tsx`, if the page has associated skills.

**Preview: https://aatuvai-2026-06-24-add-skills-banner-component.d2mrezcly5gcqm.amplifyapp.com/docs/identity-governance/access-lists/guide/**