### PR TITLE
Revert "Bump js-yaml from 4.2.0 to 5.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "hast": "^1.0.0",
     "http-server": "14.1.1",
     "jest": "^30.4.2",
-    "js-yaml": "^5.1.0",
+    "js-yaml": "^4.2.0",
     "loadr": "^0.1.1",
     "mdast": "^3.0.0",
     "mdast-util-frontmatter": "^2.0.1",

--- a/server/llms/build-sections.ts
+++ b/server/llms/build-sections.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { load } from "js-yaml";
+import yaml from "js-yaml";
 import path from "path";
 
 // the Section format from the signalwire/docusaurus-plugin-llms-txt plugin, used to define sections in the generated llms.txt file
@@ -38,7 +38,7 @@ function readFrontmatterData(filePath: string): {
     const match = content.match(/^---\n([\s\S]*?)\n---/);
     // match[1] is the captured YAML frontmatter string. Cast to a known shape to safely access named fields
     if (!match) return { title: undefined, description: undefined };
-    const frontmatter = load(match[1]) as Record<string, unknown>;
+    const frontmatter = yaml.load(match[1]) as Record<string, unknown>;
     // extract and return the title and description fields (if they exist and are strings)
     const title = frontmatter?.title;
     const description = frontmatter?.description;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11650,17 +11650,10 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0, js-yaml@^4.1.0:
+js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.1.0.tgz#c084ac880197833810a69e9c7e51eae12ff35448"
-  integrity sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Reverts gravitational/docs-website#727 due to failed deployment https://gravitational.slack.com/archives/C04UFRT5Z53/p1782737993639949