### PR TITLE
Fix homepage hero scrolling over the navbar

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -4,7 +4,7 @@
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  z-index: 3000;
   border-radius: var(--m-1);
   color: var(--color-black);
   line-height: 1.57143;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -140,7 +140,8 @@
   --ifm-navbar-padding-horizontal: 0;
   --ifm-navbar-shadow: none;
 
-  --ifm-z-index-fixed: 1;
+  /* default */
+  --ifm-z-index-fixed: 200;
 
   --ifm-menu-link-sublist-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='7' viewBox='0 0 12 7' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0.529259 0.646447C0.724521 0.451184 1.0411 0.451184 1.23637 0.646447L5.88281 5.29289L10.5293 0.646447C10.7245 0.451184 11.0411 0.451184 11.2364 0.646447C11.4316 0.841709 11.4316 1.15829 11.2364 1.35355L6.23637 6.35355C6.0411 6.54882 5.72452 6.54882 5.52926 6.35355L0.529259 1.35355C0.333997 1.15829 0.333997 0.841709 0.529259 0.646447Z' fill='black' fill-opacity='0.72'/%3E%3C/svg%3E");
 


### PR DESCRIPTION
**Problem:** On the docs homepage, the hero search bar scrolls over the top navbar instead of behind it.

**Cause:** PR #704 set the navbar's `--ifm-z-index-fixed` to `1` so its new full-screen `Modal` (also `z-index: 1`, rendered later in the DOM) would cover the navbar via paint order. The side effect: the navbar dropped to the same layer as the hero section (`.docsHeader` is `position: relative; z-index: 1`), so the hero tied the navbar and won on DOM order, scrolling over it.

**Fix:**
- Restore `--ifm-z-index-fixed` to `200` (default, could remove but left for clarity) so the navbar sits above positioned page content again.
- Raise `Modal` to `z-index: 3000` so the dialog still covers the navbar (and other chrome) without needing the navbar demoted.

**Testing:** Verified the homepage hero now scrolls behind the navbar, and the "Install Skills" dialog (opened from the "Build with Agents" dropdown on skill-enabled docs pages) still covers the navbar with its backdrop.