### PR TITLE
Make the "Install Skills" dropdown item visible on all pages

### DIFF
--- a/src/components/PageActions/PageActions.stories.tsx
+++ b/src/components/PageActions/PageActions.stories.tsx
@@ -74,7 +74,8 @@ export const ViewAsMarkdownClick: Story = {
               name: "test-skill",
               readableName: "Test Skill",
               description: "This is a test skill.",
-              installCommand: "npx skills add test-skill-url",
+              installCommand:
+                "npx skills add https://github.com/gravitational/teleport",
               rawSourceUrl:
                 "https://github.com/gravitational/teleport/tree/master/skills/test-skill/SKILL.md",
             },
@@ -114,7 +115,8 @@ export const DropdownModalOpens: Story = {
               name: "test-skill",
               readableName: "Test Skill",
               description: "This is a test skill.",
-              installCommand: "npx skills add test-skill-url",
+              installCommand:
+                "npx skills add https://github.com/gravitational/teleport",
               rawSourceUrl:
                 "https://github.com/gravitational/teleport/tree/master/skills/test-skill/SKILL.md",
             },
@@ -137,7 +139,9 @@ export const DropdownModalOpens: Story = {
       );
       await userEvent.click(canvas.getByText("Install Skills"));
       expect(
-        canvas.getByText("npx skills add test-skill-url"),
+        canvas.getByText(
+          "npx skills add https://github.com/gravitational/teleport",
+        ),
       ).toBeInTheDocument();
     });
   },
@@ -146,23 +150,8 @@ export const DropdownModalOpens: Story = {
 export const DropdownModalClosesWhenClickingOutside: Story = {
   render: () => (
     <WithFeedbackContext>
-      <ExclusivityContext.Provider
-        value={{
-          skillsForPage: [
-            {
-              name: "test-skill",
-              readableName: "Test Skill",
-              description: "This is a test skill.",
-              installCommand: "npx skills add test-skill-url",
-              rawSourceUrl:
-                "https://github.com/gravitational/teleport/tree/master/skills/test-skill/SKILL.md",
-            },
-          ],
-        }}
-      >
-        <PageActions pathname="/test" emitEvent={collectEvents()} />
-        <button>Click outside of the dropdown</button>
-      </ExclusivityContext.Provider>
+      <PageActions pathname="/test" emitEvent={collectEvents()} />
+      <button>Click outside of the dropdown</button>
     </WithFeedbackContext>
   ),
   play: async ({ canvasElement, step }) => {
@@ -180,7 +169,9 @@ export const DropdownModalClosesWhenClickingOutside: Story = {
         await userEvent.click(canvas.getByText("Install Skills"));
         await waitFor(() =>
           expect(
-            canvas.getByText("npx skills add test-skill-url"),
+            canvas.getByText(
+              "npx skills add https://github.com/gravitational/teleport",
+            ),
           ).toBeInTheDocument(),
         );
 
@@ -189,7 +180,9 @@ export const DropdownModalClosesWhenClickingOutside: Story = {
         );
         await waitFor(() =>
           expect(
-            canvas.queryByText("npx skills add test-skill-url"),
+            canvas.queryByText(
+              "npx skills add https://github.com/gravitational/teleport",
+            ),
           ).not.toBeInTheDocument(),
         );
       },

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -1,5 +1,4 @@
 import { getReportIssueURL } from "@site/src/utils/github-issue";
-import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import styles from "./PageActions.module.css";
 import Icon from "../Icon";
 import ThumbsFeedback from "../ThumbsFeedback";
@@ -7,12 +6,11 @@ import {
   copyPageContentAsMarkdown,
   normalizeMarkdownPathname,
 } from "@site/src/utils/markdown";
-import { Fragment, useContext, useState } from "react";
+import { useState } from "react";
 import { trackEvent } from "@site/src/utils/analytics";
 import Dropdown, { DrodownItemProps as DropdownItem } from "./Dropdown";
-import { SkillInfo } from "@site/scripts/prepare-files.mjs";
 import Pre from "@site/src/theme/MDXComponents/Pre";
-import ExclusivityContext from "../ExclusivityBanner/context";
+import skills from "@site/data/skills.json";
 
 type PageActionsProps = {
   pathname: string;
@@ -20,12 +18,45 @@ type PageActionsProps = {
 };
 
 const PageActions: React.FC<PageActionsProps> = ({ pathname, emitEvent }) => {
-  const { frontMatter } = useDoc();
   const [copiedMessage, setCopiedMessage] = useState<string>("Copy for LLM");
-  const exclusivity = useContext(ExclusivityContext);
-  const skillsForPage: SkillInfo[] = exclusivity?.skillsForPage ?? [];
+
+  const allSkills = skills.find((skill) => skill.name === "all-skills") || {
+    name: "all-skills",
+    readableName: "all skills",
+    description:
+      "Install all available skills. This will install all skills found in the Teleport repository.",
+    installCommand: "npx skills add https://github.com/gravitational/teleport",
+    rawSourceUrl:
+      "https://github.com/gravitational/teleport/tree/master/skills/README.md",
+  };
 
   const dropdownItems: DropdownItem[] = [
+    {
+      type: "modal",
+      label: "Install Skills",
+      icon: "lightbulb",
+      onClick: () => {
+        trackEvent({
+          event_name: "skill_install_clicked",
+          emitEvent: emitEvent,
+        });
+      },
+      content: (
+        <>
+          <h3>Install {allSkills.readableName}</h3>
+          <div style={{ marginBottom: "1.5rem" }}>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: allSkills.description,
+              }}
+            />
+            <Pre className={styles.installCommand}>
+              <div className="hljs">{allSkills.installCommand}</div>
+            </Pre>
+          </div>
+        </>
+      ),
+    },
     {
       type: "button",
       label: copiedMessage,
@@ -62,39 +93,6 @@ const PageActions: React.FC<PageActionsProps> = ({ pathname, emitEvent }) => {
       target: "_blank",
     }, */
   ];
-
-  if (skillsForPage.length > 0) {
-    dropdownItems.unshift({
-      type: "modal",
-      label: "Install Skills",
-      icon: "lightbulb",
-      onClick: () => {
-        trackEvent({
-          event_name: "skill_install_clicked",
-          emitEvent: emitEvent,
-        });
-      },
-      content: (
-        <>
-          {skillsForPage.map((skill: SkillInfo) => (
-            <Fragment key={skill.name}>
-              <h3>Install {skill.readableName}</h3>
-              <div style={{ marginBottom: "1.5rem" }}>
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: skill.description,
-                  }}
-                />
-                <Pre className={styles.installCommand}>
-                  <div className="hljs">{skill.installCommand}</div>
-                </Pre>
-              </div>
-            </Fragment>
-          ))}
-        </>
-      ),
-    });
-  }
 
   return (
     <div className={styles.pageActions}>


### PR DESCRIPTION
This PR updates the `PageActions` with the following changes:
1. Instead of displaying the "Install Skills" dropdown item only if the page has specific skills attached to it, display the item on all pages
2. In the opening modal, display the command covering all skills found in the Teleport repository
3. Fix the related Storybook interaction test