### PR TITLE
Improved dev scripting for docs authoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+devtools/.dev.pid
+
 # Docs
 versioned_docs/*
 !versioned_docs/.gitkeep

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -1,0 +1,178 @@
+# devtools — a faster, quieter dev server for docs-website
+
+A drop-in replacement for `yarn dev` (`scripts/start-dev.sh`) that fixes the
+three things that make the stock workflow painful:
+
+| Symptom (old `yarn dev`) | Cause | Fixed here by |
+| --- | --- | --- |
+| Browser tab jumps to a new port, stealing focus | Server restarted on every include edit; the orphaned old `node` kept port 3000, so the new one grabbed 3001 and opened a new tab | **One persistent server**, started with `--no-open`, that is **never restarted** during a session |
+| Slow, and slower after every include edit | `yarn clear` nuked the Docusaurus cache on each restart → cold recompile | No restarts, no cache clears — include edits recompile only the affected pages via HMR |
+| Leftover `watchexec`/`node` processes pile up; port conflicts | Teardown killed only direct shell children, orphaning the `node` grandchild | Server runs in **its own process group**; the whole group is killed on exit, and a preflight step reaps orphans |
+| Every save triggers a full rsync of ~2,100 files | One watcher re-`rsync`ed all versions on any change | **Incremental single-file** copies |
+| The `node` server balloons to multiple GB | The dev server compiles **all** doc versions, keeps the debug plugin's full content graph resident, and builds source maps | **By default builds only the edge version, drops the debug plugin, and skips source maps** — see [Memory](#memory) |
+
+This tooling is intentionally **external and additive**: it lives under
+`devtools/`, which is ignored via `.git/info/exclude` (not the tracked
+`.gitignore`), so it never appears in `git status` and never modifies a tracked
+file. It is maintained out-of-band from the repo.
+
+## Requirements
+
+- macOS (uses FSEvents-backed recursive `fs.watch`) and Node ≥ 22 — both already
+  required by the repo. **No new dependencies.**
+
+## Install
+
+Clone or copy this gist into `devtools/` within the `docs-website` directory.
+
+## Usage
+
+```bash
+./devtools/dev                 # prepare-files once, then start a persistent server on :3000
+./devtools/dev --open          # …and open a browser tab once, after first compile
+./devtools/dev --port 3001     # use a different port
+./devtools/dev --no-prepare    # skip the initial prepare-files (reuse existing docs/ output)
+./devtools/dev --host 0.0.0.0  # bind all interfaces (Docker)
+./devtools/dev --verbose       # log every file event
+
+./devtools/dev reap            # kill ALL stray docs dev processes (incl. legacy start-dev.sh) + free ports
+./devtools/dev stop            # stop the session this tool started
+./devtools/dev selftest        # read-only: validate the content→docs mapping + include graph
+```
+
+Suggested shell shortcut (fish), since `package.json` is intentionally left
+untouched:
+
+```fish
+abbr -a dev './devtools/dev'
+```
+
+Ctrl-C stops cleanly: no orphaned processes, no leaked ports.
+
+If you ever hit a stale port or find leftover processes from a previous
+`yarn dev`, run `./devtools/dev reap` to clean everything up.
+
+## Memory
+
+A stock `docusaurus start` for this site compiles **all three** doc versions
+(17.x, 18.x, edge), keeps `@docusaurus/plugin-debug`'s full content/route graph
+resident, and generates source maps — so the long-running `node` process can
+sit at several GB. Most of that is wasted while you're editing one version.
+
+By **default** this tool trims the dev server to the low-risk essentials:
+
+- **only the edge version is compiled** (`onlyIncludeVersions: ['current']`),
+  served at `/`. This is the biggest lever — it removes ~2/3 of the MDX/route
+  module graph from memory.
+- **the debug plugin is dropped** (it exists only to serve `/__docusaurus/` and
+  pins every plugin's content in memory).
+- **source maps are disabled** (large dev-heap + rebuild-time cost; irrelevant
+  to docs authoring).
+
+None of this touches the tracked `docusaurus.config.ts`. It's applied by a
+dev-only wrapper config, `devtools/docusaurus.dev.config.ts`, which imports the
+real config and tweaks a copy in memory; the tool passes it via
+`docusaurus start --config …` and a few `DEV_*` env vars.
+
+Flags to dial it back when you need more:
+
+```bash
+./devtools/dev --versions all        # compile every version (stock scope)
+./devtools/dev --versions 18.x       # compile only 18.x, served at /
+./devtools/dev --versions current,18.x
+./devtools/dev --debug               # keep the /__docusaurus/ debug plugin
+./devtools/dev --sourcemaps          # keep webpack source maps
+./devtools/dev --full                # opt out entirely: stock docusaurus start
+./devtools/dev --heap 4096           # cap V8 old-space (safety valve, not a reducer)
+```
+
+The file watcher still syncs **all** versions to disk regardless — only the
+Docusaurus *compile* is scoped — so switching `--versions` never leaves stale
+generated output. Editing a non-compiled version syncs fine but won't render
+until you include it.
+
+### Keeping both `/` and `/ver/NN.x/` working
+
+When a single non-root version is built (e.g. the edge version, normally at
+`/ver/19.x/`), the wrapper mounts it at the site **root** so `/`, the navbar,
+the footer, and the homepage all resolve. A version can only live at one path,
+so its old `/ver/19.x/...` URLs would otherwise 404. `@docusaurus/plugin-client-redirects`
+only runs at build time, so the wrapper instead registers a **dev-only
+catch-all redirect route** (`devtools/dev-ver-redirect.js`) that client-redirects
+`/ver/NN.x/...` → `/...`. Version-switcher links, old bookmarks, and hardcoded
+`/ver/NN.x/...` links keep working (the URL normalizes to the root path). This
+only activates when a version is remapped to root; `--versions current,18.x`
+and `--versions all` leave every version at its native path.
+
+## How it works
+
+Docusaurus watches `docs/` and `versioned_docs/`, but authored content lives in
+`content/<version>/docs/pages/`. Pages are **copied** into the Docusaurus dirs;
+includes (`(!path!)`) are **not** — `server/remark-includes.ts` reads them
+straight from `content/` at compile time and never registers them as bundler
+dependencies. That's why editing an include is invisible to HMR and why the old
+script resorted to a full restart.
+
+This tool:
+
+1. Runs `yarn prepare-files` once (full, correct initial build), then starts a
+   single `docusaurus start --no-open` that stays up for the whole session.
+2. Builds an **include-dependency graph** (`lib/includes-graph.mjs`) by scanning
+   every `.mdx` under each version's `pages/` for `(!…!)` directives, resolving
+   targets exactly like `remark-includes` (`join(content/<version>, path)`).
+3. Watches `content/` and, per change:
+   - **page** edited/created → copy that one file to its `docs/`/`versioned_docs/`
+     target (HMR picks it up);
+   - **page** deleted → remove the target;
+   - **include / snippet** edited → look up every page that transitively includes
+     it and re-emit those pages, toggling a trailing newline (inert in MDX) so the
+     bytes always change and rspack recompiles them — re-reading the fresh
+     include. **No restart, no cache clear.**
+   - **sidebar.json** → copy to the matching sidebar target;
+   - **tags.yml** → copy into every version dir.
+
+The content→destination mapping mirrors `scripts/prepare-files.mts` /
+`server/config-site.ts` byte-for-byte (verified by `selftest`).
+
+## When a restart is still needed
+
+A few changes affect server-global state that HMR can't hot-swap. The tool logs
+a warning; stop (Ctrl-C) and rerun to apply:
+
+- `content/<version>/docs/config.json` **redirects** (variables usually apply on
+  recompile, but redirects are wired at server start).
+- `config.json` (the top-level version list) — also needs a fresh
+  `prepare-files`, which happens automatically on the next `./devtools/dev`.
+
+## Files
+
+```
+devtools/
+  dev                  # bash launcher (cd to repo root, exec node dev.mjs)
+  dev.mjs              # orchestration: args, prepare-files, spawn server, watch, teardown
+  docusaurus.dev.config.ts  # dev-only wrapper config: trims versions/debug/sourcemaps for memory
+  selftest.mjs         # read-only mapping + graph validation
+  inttest.mjs          # integration test of the watcher→apply→docs/ pipeline (writes temp files, cleans up)
+  lib/
+    config.mjs         # config.json → version source/dest mapping
+    includes-graph.mjs # (!…!) dependency graph + transitive reverse lookup
+    sync.mjs           # classify a changed path; emit/bump/delete/copy to docs/
+    apply.mjs          # turn a debounced batch of paths into destination writes
+    watcher.mjs        # native recursive fs.watch, debounced/batched
+    process.mjs        # process-group spawn, port/orphan reaping, teardown
+    log.mjs            # tiny timestamped logger
+```
+
+## Tests
+
+```bash
+./devtools/dev selftest     # fast, read-only, safe to run anytime
+node devtools/inttest.mjs   # end-to-end watcher test (creates/removes temp files under the current version)
+```
+
+## Maintenance notes
+
+- If the upstream mapping logic in `server/config-site.ts` or
+  `scripts/prepare-files.mts` changes (e.g. how versions map to `docs/` vs
+  `versioned_docs/`), update `lib/config.mjs` to match, then run
+  `./devtools/dev selftest` to confirm.

--- a/devtools/dev
+++ b/devtools/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Thin launcher for the docs-website dev tool. Ensures we always run from the
+# repo root (so relative paths in prepare-files / docusaurus resolve correctly)
+# regardless of where this is invoked from.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+exec node devtools/dev.mjs "$@"

--- a/devtools/dev-ver-redirect.js
+++ b/devtools/dev-ver-redirect.js
@@ -1,0 +1,20 @@
+// Dev-only redirect component used by devtools/docusaurus.dev.config.ts.
+//
+// When the trimmed dev build remaps the edge version to the site root, that
+// version's production path (/ver/NN.x/...) has no native routes. This
+// component is mounted as a catch-all at that old prefix and client-redirects
+// to the equivalent root path, so version-switcher links, old bookmarks, and
+// hardcoded /ver/NN.x/... links keep resolving instead of hitting Not Found.
+//
+// Plain ESM + React.createElement (no JSX / TS) so webpack needs no extra
+// loader config to build a file living outside src/.
+
+import React from "react";
+import { Redirect, useLocation } from "@docusaurus/router";
+
+export default function DevVerRedirect() {
+  const { pathname, search, hash } = useLocation();
+  // Strip a leading /ver/<name> segment; fall back to "/" for the bare prefix.
+  const target = (pathname.replace(/^\/ver\/[^/]+/, "") || "/") + search + hash;
+  return React.createElement(Redirect, { to: target });
+}

--- a/devtools/dev.mjs
+++ b/devtools/dev.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+// Fast, reliable dev server for the Teleport docs-website.
+//
+// Design goals (vs. the old scripts/start-dev.sh):
+//   • ONE persistent `docusaurus start` that is never restarted mid-session, so
+//     it never steals focus with a new browser tab or fights over the port.
+//   • Incremental, single-file content sync (not a full rsync of ~2,100 files).
+//   • Include edits reflected WITHOUT a restart or cache clear, via a
+//     precomputed include-dependency graph (see lib/includes-graph.mjs).
+//   • Bulletproof teardown: the server runs in its own process group and the
+//     whole group is killed on exit; a preflight step reaps orphans.
+//
+// This tool is intentionally external/additive: it lives under devtools/ (which
+// is git-ignored via .git/info/exclude) and never edits tracked repo files.
+//
+// Usage:
+//   devtools/dev [--port N] [--host H] [--open] [--no-prepare] [--verbose]
+//   devtools/dev reap        # kill ALL stray docs dev processes + free ports
+//   devtools/dev stop        # stop the session started by this tool
+//   devtools/dev selftest    # validate mapping + include graph, then exit
+
+import { existsSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync, spawn } from "node:child_process";
+
+import { log, setVerbose, paint } from "./lib/log.mjs";
+import { loadVersions } from "./lib/config.mjs";
+import { IncludeGraph } from "./lib/includes-graph.mjs";
+import { watchPaths } from "./lib/watcher.mjs";
+import { applyBatch } from "./lib/apply.mjs";
+import {
+  reapOwn,
+  reapAll,
+  spawnServer,
+  killServer,
+  writePidfile,
+  removePidfile,
+  freePort,
+  pidsOnPort,
+} from "./lib/process.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+process.chdir(ROOT);
+const rel = (p) => (p ? relative(ROOT, p) : p);
+
+// ---- arg parsing --------------------------------------------------------
+function parseArgs(argv) {
+  const opts = {
+    port: Number(process.env.DEV_PORT) || 3000,
+    host: undefined,
+    open: false,
+    prepare: true,
+    verbose: false,
+    cmd: "start",
+    // Memory profile (see the wrapper config, devtools/docusaurus.dev.config.ts).
+    // Default: compile only the edge version, drop the debug plugin, and skip
+    // source maps — the low-risk trims that cut the dev server's footprint most.
+    versions: "current", // "current" | "all" | comma list like "current,18.x"
+    debug: false, // keep @docusaurus/plugin-debug
+    sourcemaps: false, // keep webpack source maps
+    full: false, // shorthand: behave exactly like plain `docusaurus start`
+    heap: undefined, // NODE_OPTIONS --max-old-space-size (MB), optional cap
+  };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "reap" || a === "stop" || a === "selftest" || a === "help") opts.cmd = a;
+    else if (a === "--port") opts.port = Number(argv[++i]);
+    else if (a === "--host") opts.host = argv[++i];
+    else if (a === "--open") opts.open = true;
+    else if (a === "--no-prepare") opts.prepare = false;
+    else if (a === "--verbose" || a === "-v") opts.verbose = true;
+    else if (a === "--versions") opts.versions = argv[++i];
+    else if (a === "--all-versions") opts.versions = "all";
+    else if (a === "--debug") opts.debug = true;
+    else if (a === "--sourcemaps") opts.sourcemaps = true;
+    else if (a === "--full") opts.full = true;
+    else if (a === "--heap") opts.heap = Number(argv[++i]);
+    else if (a === "--help" || a === "-h") opts.cmd = "help";
+    else rest.push(a);
+  }
+  return opts;
+}
+
+// Resolve a user version selector into Docusaurus version names ("current" for
+// the edge version, "NN.x" otherwise). Accepts the edge version's real name
+// (e.g. "19.x") as an alias for "current". Returns { keep, all } or throws.
+function resolveVersions(sel, versions) {
+  if (!sel || sel.toLowerCase() === "all") return { all: true, keep: [] };
+  const nameFor = (v) => (v.isCurrent ? "current" : v.name);
+  const known = new Map(); // accepted token -> canonical docusaurus name
+  for (const v of versions) {
+    known.set(nameFor(v), nameFor(v));
+    known.set(v.name, nameFor(v)); // allow "19.x" as alias for "current"
+  }
+  const keep = [];
+  for (const tok of sel.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const canon = known.get(tok);
+    if (!canon) {
+      const opts = [...new Set(known.keys())].join(", ");
+      throw new Error(`unknown version "${tok}" (known: ${opts}, or "all")`);
+    }
+    if (!keep.includes(canon)) keep.push(canon);
+  }
+  return { all: false, keep };
+}
+
+const opts = parseArgs(process.argv.slice(2));
+setVerbose(opts.verbose);
+
+// ---- subcommands --------------------------------------------------------
+if (opts.cmd === "help") {
+  log.plain(`
+${paint("bold", "devtools/dev")} — incremental dev server for docs-website
+
+  devtools/dev [options]      start the dev server (default)
+  devtools/dev reap           kill ALL stray docs dev processes and free ports
+  devtools/dev stop           stop the session started by this tool
+  devtools/dev selftest       validate content mapping + include graph
+
+Options:
+  --port N        port to serve on (default 3000, or $DEV_PORT)
+  --host H        bind host (e.g. 0.0.0.0 for Docker)
+  --open          open a browser tab once, after first successful compile
+  --no-prepare    skip the initial "yarn prepare-files" (reuse existing output)
+  --verbose, -v   log every file event
+
+Memory (dev server footprint — defaults trade little for a lot):
+  --versions LIST compile only these versions (default "current"; the edge
+                  version. Comma list ok, e.g. "current,18.x"; "all" for every
+                  version — the stock Docusaurus behavior)
+  --all-versions  alias for --versions all
+  --debug         keep @docusaurus/plugin-debug (off by default; it pins all
+                  content in memory to serve /__docusaurus/)
+  --sourcemaps    keep webpack source maps (off by default)
+  --full          behave exactly like plain "docusaurus start": all versions,
+                  debug plugin on, source maps on (no dev wrapper config)
+  --heap MB       cap V8 old-space at MB (adds --max-old-space-size); forces
+                  earlier GC. A safety cap, not a reducer — omit unless needed.
+`);
+  process.exit(0);
+}
+
+if (opts.cmd === "reap") {
+  const n = reapAll(ROOT);
+  log.info(`reaped ${n} process(es)/port(s)`);
+  process.exit(0);
+}
+
+if (opts.cmd === "stop") {
+  const n = freePort(opts.port);
+  log.info(n ? `stopped server on :${opts.port}` : `nothing running on :${opts.port}`);
+  removePidfile(ROOT);
+  process.exit(0);
+}
+
+if (opts.cmd === "selftest") {
+  const { runSelftest } = await import("./selftest.mjs");
+  process.exit(runSelftest(ROOT) ? 0 : 1);
+}
+
+// ---- start --------------------------------------------------------------
+if (!existsSync(join(ROOT, "config.json"))) {
+  log.error(`config.json not found in ${ROOT} — is this the docs-website root?`);
+  process.exit(1);
+}
+
+const versions = loadVersions(ROOT);
+log.step(
+  `versions: ${versions
+    .map((v) => `${v.name}${v.isCurrent ? paint("gray", "(current→docs/)") : ""}`)
+    .join(", ")}`,
+);
+
+// Preflight: reap our own previous session and free the target port.
+reapOwn(ROOT, opts.port);
+if (pidsOnPort(opts.port).length) {
+  log.error(`port ${opts.port} is still in use after cleanup; try: devtools/dev reap`);
+  process.exit(1);
+}
+
+// 1) Full prepare-files once (also does the initial content copy).
+if (opts.prepare) {
+  log.step("running prepare-files (one-time full build of docs/ + sidebars)…");
+  const t0 = Date.now();
+  const viteNode = join(ROOT, "node_modules", ".bin", "vite-node");
+  const r = existsSync(viteNode)
+    ? spawnSync(viteNode, ["./scripts/prepare-files.mts"], { cwd: ROOT, stdio: "inherit" })
+    : spawnSync("yarn", ["prepare-files"], { cwd: ROOT, stdio: "inherit" });
+  if (r.status !== 0) {
+    log.error("prepare-files failed; aborting");
+    process.exit(1);
+  }
+  log.info(`prepare-files done in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+} else {
+  log.warn("skipping prepare-files (--no-prepare); using existing docs/ output");
+}
+
+// 2) Resolve the memory profile and build the wrapper-config env.
+//    --full opts out entirely (stock `docusaurus start`, all versions).
+const stripDebug = !opts.full && !opts.debug;
+const noSourcemaps = !opts.full && !opts.sourcemaps;
+let sel;
+try {
+  sel = opts.full ? { all: true, keep: [] } : resolveVersions(opts.versions, versions);
+} catch (e) {
+  log.error(String(e.message || e));
+  process.exit(1);
+}
+
+const useWrapper = !sel.all || stripDebug || noSourcemaps;
+const devEnv = {};
+if (useWrapper) {
+  devEnv.DEV_ONLY_VERSIONS = sel.all ? "all" : sel.keep.join(",");
+  devEnv.DEV_STRIP_DEBUG = stripDebug ? "1" : "0";
+  devEnv.DEV_NO_SOURCEMAPS = noSourcemaps ? "1" : "0";
+}
+if (opts.heap) {
+  devEnv.NODE_OPTIONS =
+    `${process.env.NODE_OPTIONS || ""} --max-old-space-size=${opts.heap}`.trim();
+}
+const devConfig = useWrapper
+  ? join(ROOT, "devtools", "docusaurus.dev.config.ts")
+  : undefined;
+
+const liveVersions = sel.all ? "all" : sel.keep.join(", ");
+log.step(
+  `memory profile: versions=${paint("bold", liveVersions)}` +
+    ` debug=${stripDebug ? "off" : "on"}` +
+    ` sourcemaps=${noSourcemaps ? "off" : "on"}` +
+    (opts.heap ? ` heap=${opts.heap}MB` : "") +
+    (opts.full ? paint("gray", "  (--full: stock docusaurus)") : ""),
+);
+if (!sel.all) {
+  log.plain(
+    paint(
+      "gray",
+      `  only ${liveVersions} is compiled; other versions still sync to disk but` +
+        ` aren't served. Use --versions all (or --full) to build everything.`,
+    ),
+  );
+}
+
+// 3) Spawn the persistent Docusaurus server (starts its long initial compile).
+const url = `http://localhost:${opts.port}/`;
+let opened = false;
+const server = spawnServer(ROOT, {
+  port: opts.port,
+  host: opts.host,
+  devConfig,
+  env: devEnv,
+  onReady: () => {
+    log.info(paint("green", `ready → ${url}`));
+    if (opts.open && !opened) {
+      opened = true;
+      spawn("open", [url], { stdio: "ignore" }).unref();
+    }
+  },
+});
+writePidfile(ROOT, { serverPid: server.pid, port: opts.port });
+
+server.on("exit", (code, signal) => {
+  if (shuttingDown) return;
+  log.error(`docusaurus server exited (code=${code} signal=${signal}) — shutting down`);
+  shutdown(1);
+});
+
+// 4) Build the include-dependency graph (overlaps the server's initial compile).
+log.step("building include-dependency graph…");
+const graph = new IncludeGraph(versions);
+const g = graph.build();
+log.info(`graph: ${g.files} source files, ${g.edges} include targets (${g.ms}ms)`);
+
+// 5) Watch content and react incrementally.
+const specs = [];
+for (const v of versions) {
+  specs.push({ dir: join(v.root, "docs"), recursive: true });
+  const ex = join(v.root, "examples");
+  if (existsSync(ex)) specs.push({ dir: ex, recursive: true });
+  specs.push({ dir: v.root, recursive: false }); // top-level targets (CHANGELOG.md, …)
+}
+specs.push({ dir: ROOT, recursive: false }); // tags.yml, root config.json
+
+const ctx = { root: ROOT, versions, graph, rel };
+const closeWatch = watchPaths(specs, (paths) => applyBatch(paths, ctx));
+log.step(`watching content/ for changes — edit pages & includes freely`);
+log.plain(
+  paint(
+    "gray",
+    `  server: ${url}   (Ctrl-C to stop cleanly — no orphans, no port leaks)`,
+  ),
+);
+
+// ---- teardown -----------------------------------------------------------
+let shuttingDown = false;
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log.step("shutting down…");
+  try {
+    closeWatch();
+  } catch {}
+  removePidfile(ROOT);
+
+  // If the server is already gone, exit now.
+  if (!server || server.exitCode !== null || server.signalCode) {
+    return process.exit(code);
+  }
+  // Otherwise wait for the whole server process group to actually die before we
+  // exit — so we never abandon the SIGKILL escalation and leave an orphan.
+  server.once("exit", () => process.exit(code));
+  killServer(server); // SIGTERM now, SIGKILL the group at +2s
+  setTimeout(() => process.exit(code), 4000).unref?.(); // hard cap
+}
+
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(sig, () => shutdown(0));
+}
+process.on("uncaughtException", (err) => {
+  log.error(`uncaught: ${err?.stack || err}`);
+  shutdown(1);
+});

--- a/devtools/docusaurus.dev.config.ts
+++ b/devtools/docusaurus.dev.config.ts
@@ -1,0 +1,116 @@
+// Dev-only wrapper around the repo's tracked docusaurus.config.ts.
+//
+// Loaded via `docusaurus start --config devtools/docusaurus.dev.config.ts`
+// (wired up by devtools/dev.mjs). It trims what the dev server compiles so the
+// long-running `node` process uses far less memory. It NEVER edits the tracked
+// config — it imports it and tweaks a copy, driven entirely by env vars that
+// devtools/dev.mjs sets:
+//
+//   DEV_ONLY_VERSIONS  comma-separated version names to build, e.g.
+//                      "current" or "current,18.x". Empty / "all" = no limit.
+//                      Building 1 of 3 versions is the single biggest win:
+//                      ~1/3 the MDX/route/module graph held in memory.
+//   DEV_STRIP_DEBUG    "1" => drop @docusaurus/plugin-debug, which otherwise
+//                      keeps every plugin's content + route data resident so it
+//                      can render the /__docusaurus/ inspector.
+//   DEV_NO_SOURCEMAPS  "1" => disable webpack source maps (a large share of dev
+//                      heap + a chunk of rebuild time). Costs JS-level
+//                      debuggability of the site's own React, which docs
+//                      authoring never needs.
+//
+// Docusaurus loads config via jiti, so this .ts file importing the base .ts
+// config Just Works — no build step, no new deps.
+
+import type { Config, PluginConfig } from "@docusaurus/types";
+import baseConfig from "../docusaurus.config";
+
+const config: Config = baseConfig;
+const plugins: PluginConfig[] = (config.plugins ?? []) as PluginConfig[];
+
+// Original paths of versions we remap to "/" (e.g. "ver/19.x"). Their native
+// routes disappear when moved to root, so we re-add them as redirect routes.
+const remappedFromPaths: string[] = [];
+
+// ---- 1) restrict which doc versions are compiled ------------------------
+const only = (process.env.DEV_ONLY_VERSIONS || "").trim();
+if (only && only.toLowerCase() !== "all") {
+  const keep = only
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const docs = plugins.find(
+    (p): p is [string, Record<string, any>] =>
+      Array.isArray(p) && p[0] === "@docusaurus/plugin-content-docs",
+  );
+
+  if (docs && keep.length) {
+    const opts = docs[1];
+    opts.onlyIncludeVersions = keep;
+
+    // Docusaurus requires lastVersion (if set) to be one of the built versions.
+    if (!opts.lastVersion || !keep.includes(opts.lastVersion)) {
+      opts.lastVersion = keep.includes("current") ? "current" : keep[0];
+    }
+
+    // Serve the "last" version at the site root so http://localhost:PORT/
+    // resolves instead of 404ing (the edge version is normally at /ver/NN.x).
+    opts.versions = opts.versions || {};
+    const lv = (opts.versions[opts.lastVersion] ||= {});
+    const origPath = typeof lv.path === "string" ? lv.path.replace(/^\/+/, "") : "";
+    if (origPath) remappedFromPaths.push(origPath);
+    lv.path = "";
+    lv.noIndex = false;
+  }
+}
+
+// ---- 1b) keep the old /ver/NN.x/... URLs working (dev redirect) ---------
+// A version can only be mounted at one path, so once it's at "/", its previous
+// /ver/NN.x/... routes are gone. client-redirects only runs at build time, so
+// in dev we register a catch-all redirect route ourselves.
+if (remappedFromPaths.length) {
+  const redirectComponent = require.resolve("./dev-ver-redirect.js");
+  config.plugins = [
+    ...(config.plugins ?? []),
+    function devtoolsVerRedirect() {
+      return {
+        name: "devtools-ver-redirect",
+        contentLoaded({ actions }: { actions: any }) {
+          for (const p of remappedFromPaths) {
+            actions.addRoute({
+              path: `/${p}`,
+              component: redirectComponent,
+              exact: false, // catch /ver/NN.x and everything under it
+            });
+          }
+        },
+      };
+    },
+  ];
+}
+
+// ---- 2) drop the debug plugin (dev-only, all-content-resident) ----------
+// Filter the CURRENT plugin list (not the snapshot captured above) so any
+// plugin added by an earlier step survives.
+if (process.env.DEV_STRIP_DEBUG === "1") {
+  config.plugins = (config.plugins ?? []).filter(
+    (p) => p !== "@docusaurus/plugin-debug",
+  );
+}
+
+// ---- 3) disable source maps -------------------------------------------
+if (process.env.DEV_NO_SOURCEMAPS === "1") {
+  config.plugins = [
+    ...(config.plugins ?? []),
+    function devtoolsNoSourcemaps() {
+      return {
+        name: "devtools-no-sourcemaps",
+        configureWebpack() {
+          return { devtool: false };
+        },
+      };
+    },
+  ];
+}
+
+export default config;

--- a/devtools/inttest.mjs
+++ b/devtools/inttest.mjs
@@ -1,0 +1,138 @@
+// Integration test for the watcher -> applyBatch -> docs/ pipeline.
+// Drives the REAL fs.watch machinery (no server) using throwaway temp files
+// under the current version, asserting each destination write. Cleans up after
+// itself so the content submodule returns to its prior state.
+//
+// Run: node devtools/inttest.mjs      (writes a couple of transient temp files)
+
+import {
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  mkdirSync,
+} from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadVersions } from "./lib/config.mjs";
+import { IncludeGraph } from "./lib/includes-graph.mjs";
+import { watchPaths } from "./lib/watcher.mjs";
+import { applyBatch } from "./lib/apply.mjs";
+import { destForPage } from "./lib/sync.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+process.chdir(ROOT);
+const rel = (p) => relative(ROOT, p);
+
+const versions = loadVersions(ROOT);
+const cur = versions.find((v) => v.isCurrent);
+
+const STAMP = "devtools-smoke";
+const pageAbs = join(cur.source, `zz-${STAMP}.mdx`);
+const inclDir = join(cur.source, "includes");
+const inclAbs = join(inclDir, `zz-${STAMP}-partial.mdx`);
+const pageDest = destForPage(pageAbs, versions);
+
+let passed = 0;
+let failed = 0;
+const ok = (m) => {
+  passed++;
+  console.log(`  ✓ ${m}`);
+};
+const no = (m) => {
+  failed++;
+  console.log(`  ✗ ${m}`);
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// Poll until predicate true or timeout (fs.watch latency is variable).
+async function until(pred, ms = 3000) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    if (pred()) return true;
+    await sleep(50);
+  }
+  return pred();
+}
+
+function cleanup() {
+  for (const p of [pageAbs, inclAbs]) rmSync(p, { force: true });
+  if (pageDest) rmSync(pageDest, { force: true });
+}
+
+async function main() {
+  cleanup(); // start clean
+  const graph = new IncludeGraph(versions);
+  graph.build();
+  const ctx = { root: ROOT, versions, graph, rel, quiet: true };
+  const close = watchPaths(specs(), (paths) => applyBatch(paths, ctx));
+
+  try {
+    // 1) Create an include + a page that references it.
+    if (!existsSync(inclDir)) mkdirSync(inclDir, { recursive: true });
+    writeFileSync(inclAbs, "SMOKE_MARKER_V1\n");
+    writeFileSync(
+      pageAbs,
+      `---\ntitle: Smoke\ndescription: smoke test\n---\n\n(!docs/pages/includes/zz-${STAMP}-partial.mdx!)\n`,
+    );
+
+    if (await until(() => existsSync(pageDest)))
+      ok(`new page synced → ${rel(pageDest)}`);
+    else no(`new page NOT synced to ${rel(pageDest)}`);
+
+    if (await until(() => graph.forward.has(pageAbs)))
+      ok(`graph learned new page's include edge`);
+    else no(`graph did not learn include edge`);
+
+    // 2) Edit the page body -> verbatim copy should reflect it.
+    const edited = readFileSync(pageAbs, "utf8") + "\nEDITED_BODY\n";
+    writeFileSync(pageAbs, edited);
+    if (await until(() => existsSync(pageDest) && readFileSync(pageDest, "utf8").includes("EDITED_BODY")))
+      ok(`page edit reflected in ${rel(pageDest)}`);
+    else no(`page edit NOT reflected in dest`);
+
+    // 3) Edit the INCLUDE -> dependent page must be re-emitted with different
+    //    bytes (proving the no-restart include-reload path fires).
+    const before = readFileSync(pageDest);
+    writeFileSync(inclAbs, "SMOKE_MARKER_V2\n");
+    if (await until(() => !readFileSync(pageDest).equals(before)))
+      ok(`include edit bumped dependent page (bytes changed, no restart)`);
+    else no(`include edit did NOT bump dependent page`);
+
+    // 3b) The bump must be semantically inert (only trailing whitespace differs).
+    const after = readFileSync(pageDest, "utf8");
+    const norm = (s) => s.replace(/\s*$/, "");
+    if (norm(after) === norm(readFileSync(pageAbs, "utf8")))
+      ok(`bump changed only trailing whitespace (content preserved)`);
+    else no(`bump altered page content unexpectedly`);
+
+    // 4) Delete the page -> dest removed, graph forgets it.
+    rmSync(pageAbs, { force: true });
+    if (await until(() => !existsSync(pageDest)))
+      ok(`page delete removed ${rel(pageDest)}`);
+    else no(`page delete did NOT remove dest`);
+  } finally {
+    close();
+    cleanup();
+  }
+
+  console.log(
+    `\ninttest: ${failed === 0 ? "PASS" : "FAIL"} (${passed} passed, ${failed} failed)`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+function specs() {
+  const s = [];
+  for (const v of versions) {
+    s.push({ dir: join(v.root, "docs"), recursive: true });
+    const ex = join(v.root, "examples");
+    if (existsSync(ex)) s.push({ dir: ex, recursive: true });
+    s.push({ dir: v.root, recursive: false });
+  }
+  s.push({ dir: ROOT, recursive: false });
+  return s;
+}
+
+main();

--- a/devtools/lib/apply.mjs
+++ b/devtools/lib/apply.mjs
@@ -1,0 +1,115 @@
+// Turns a debounced batch of changed absolute paths into the right set of
+// destination writes. Shared by dev.mjs (live) and the integration test so both
+// exercise identical logic.
+
+import { join } from "node:path";
+import { log, paint } from "./log.mjs";
+import {
+  classify,
+  emitPage,
+  bumpPage,
+  deletePage,
+  emitSidebar,
+  copyTags,
+} from "./sync.mjs";
+
+/**
+ * @param {string[]} paths absolute paths that changed
+ * @param {{root:string, versions:any[], graph:import("./includes-graph.mjs").IncludeGraph, rel:(p:string)=>string, quiet?:boolean}} ctx
+ * @returns {{pagesEmitted:string[], pagesDeleted:string[], bumped:string[], sidebars:string[], configChanged:boolean, versionConfigChanged:boolean}}
+ */
+export function applyBatch(paths, ctx) {
+  const { root, versions, graph, rel } = ctx;
+  const say = ctx.quiet ? () => {} : (m) => log.info(m);
+
+  const TAGS = join(root, "tags.yml");
+  const ROOT_CONFIG = join(root, "config.json");
+
+  const result = {
+    pagesEmitted: [],
+    pagesDeleted: [],
+    bumped: [],
+    sidebars: [],
+    configChanged: false,
+    versionConfigChanged: false,
+  };
+
+  const emitted = new Set(); // page abs written verbatim this batch
+  const toBump = new Set(); // page abs to force-recompile (include/snippet changes)
+
+  for (const abs of paths) {
+    log.debug(`event: ${rel(abs)}`);
+
+    if (abs === TAGS) {
+      copyTags(root, versions);
+      say("tags.yml → copied into all versions");
+      continue;
+    }
+    if (abs === ROOT_CONFIG) {
+      result.versionConfigChanged = true;
+      continue;
+    }
+
+    const c = classify(abs, versions);
+    if (!c) continue;
+
+    if (c.kind === "page") {
+      if (c.exists) {
+        const dest = emitPage(abs, versions);
+        graph.update(abs);
+        emitted.add(abs);
+        if (dest) {
+          result.pagesEmitted.push(dest);
+          say(`page → ${rel(dest)}`);
+        }
+      } else {
+        const dest = deletePage(abs, versions);
+        graph.remove(abs);
+        if (dest) {
+          result.pagesDeleted.push(dest);
+          say(`page removed → ${rel(dest)}`);
+        }
+      }
+    } else if (c.kind === "include") {
+      if (c.exists) graph.update(abs);
+      else graph.remove(abs);
+      const deps = graph.dependentPages(abs);
+      for (const p of deps) toBump.add(p);
+      say(`include ${rel(abs)} → ${deps.size} dependent page(s)`);
+    } else if (c.kind === "target") {
+      const deps = graph.dependentPages(abs);
+      if (deps.size) {
+        for (const p of deps) toBump.add(p);
+        say(`snippet ${rel(abs)} → ${deps.size} dependent page(s)`);
+      }
+    } else if (c.kind === "sidebar") {
+      const dest = emitSidebar(abs, versions);
+      if (dest) {
+        result.sidebars.push(dest);
+        say(`sidebar → ${rel(dest)}`);
+      }
+    } else if (c.kind === "config") {
+      result.configChanged = true;
+    }
+  }
+
+  for (const p of toBump) {
+    if (emitted.has(p)) continue; // verbatim write already forces a recompile
+    const dest = bumpPage(p, versions);
+    if (dest) result.bumped.push(dest);
+  }
+  if (result.bumped.length) {
+    say(paint("green", `recompiled ${result.bumped.length} page(s) via HMR (no restart)`));
+  }
+
+  if (result.versionConfigChanged) {
+    log.warn("config.json (version list) changed — stop & rerun devtools/dev to apply");
+  }
+  if (result.configChanged) {
+    log.warn(
+      "a version docs/config.json changed — variable/redirect changes need a restart (Ctrl-C, rerun)",
+    );
+  }
+
+  return result;
+}

--- a/devtools/lib/config.mjs
+++ b/devtools/lib/config.mjs
@@ -1,0 +1,57 @@
+// Reads config.json and derives the content -> Docusaurus file mapping.
+//
+// This mirrors, byte-for-byte, the mapping that scripts/prepare-files.mts and
+// server/config-site.ts produce, so the incremental watcher writes to exactly
+// the same destinations as a full `yarn prepare-files`:
+//
+//   - "current" version (the LAST non-deprecated entry in config.json, i.e. the
+//     edge/highest version) is copied into   docs/
+//   - every other non-deprecated version    into   versioned_docs/version-<name>/
+//
+//   - current sidebar ->                     sidebars.json
+//   - other sidebars ->                      versioned_sidebars/version-<name>-sidebars.json
+//
+// If the upstream mapping logic ever changes, update this to match.
+
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+/**
+ * @param {string} root Absolute path to the docs-website repo root.
+ * @returns {Array<{
+ *   name: string, isCurrent: boolean, root: string, source: string,
+ *   dest: string, sidebarSource: string, sidebarDest: string, configSource: string,
+ * }>}
+ */
+export function loadVersions(root) {
+  const cfg = JSON.parse(readFileSync(join(root, "config.json"), "utf8"));
+  const supported = (cfg.versions ?? []).filter((v) => !v.deprecated);
+  if (supported.length === 0) {
+    throw new Error("config.json has no non-deprecated versions");
+  }
+
+  // getCurrentVersion(): last entry in config order among supported versions.
+  const currentName = supported[supported.length - 1].name;
+
+  return supported.map((v) => {
+    const isCurrent = v.name === currentName;
+    const versionRoot = resolve(root, "content", v.name);
+    return {
+      name: v.name,
+      isCurrent,
+      // content/<name> — the rootDir remark-includes resolves (!...!) against.
+      root: versionRoot,
+      // content/<name>/docs/pages — where authored pages + includes live.
+      source: join(versionRoot, "docs", "pages"),
+      // Docusaurus docs dir this version's pages are copied into.
+      dest: isCurrent
+        ? resolve(root, "docs")
+        : resolve(root, "versioned_docs", `version-${v.name}`),
+      sidebarSource: join(versionRoot, "docs", "sidebar.json"),
+      sidebarDest: isCurrent
+        ? resolve(root, "sidebars.json")
+        : resolve(root, "versioned_sidebars", `version-${v.name}-sidebars.json`),
+      configSource: join(versionRoot, "docs", "config.json"),
+    };
+  });
+}

--- a/devtools/lib/includes-graph.mjs
+++ b/devtools/lib/includes-graph.mjs
@@ -1,0 +1,166 @@
+// Builds and maintains a dependency graph of which pages (transitively) include
+// which partials / snippet files, so that when an include changes we can
+// re-emit ONLY the affected pages instead of restarting Docusaurus.
+//
+// Why this exists: server/remark-includes.ts resolves `(!path!)` directives at
+// MDX-compile time by reading the target straight from `content/<version>/` via
+// readFileSync. Those reads are NOT registered as webpack/rspack dependencies,
+// so editing an include is invisible to Docusaurus HMR. The old start-dev.sh
+// worked around that with a full `yarn clear && docusaurus start` restart. With
+// this graph we instead touch the including pages, which Docusaurus DOES watch,
+// so it recompiles them and re-reads the fresh include — no restart needed.
+//
+// Resolution mirrors remark-includes.ts: the include path is joined onto the
+// version root (content/<version>), so `(!docs/pages/includes/x.mdx!)` resolves
+// to content/<version>/docs/pages/includes/x.mdx. Targets may be non-.mdx too
+// (code snippets under examples/, CHANGELOG.md, ...); those are captured as leaf
+// targets in the reverse map.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, sep } from "node:path";
+
+// Matches an include directive and captures the target path (first token, no
+// spaces, no `!`). Deliberately permissive: over-matching only causes a harmless
+// extra recompile, whereas under-matching would miss a needed update.
+const INCLUDE_RE = /\(!\s*([^\s!]+)[^!]*!\)/g;
+
+const isMdx = (p) => p.endsWith(".mdx") || p.endsWith(".md");
+const isInclude = (p) => p.includes(`${sep}includes${sep}`);
+
+// Recursively collect .mdx/.md files under `dir`.
+function walkMdx(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out; // dir may not exist for a given version
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      walkMdx(full, out);
+    } else if (e.isFile() && isMdx(e.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Extract the set of absolute include-target paths referenced by one file.
+function scanFile(absFile, versionRoot) {
+  let text;
+  try {
+    text = readFileSync(absFile, "utf8");
+  } catch {
+    return new Set();
+  }
+  const targets = new Set();
+  for (const m of text.matchAll(INCLUDE_RE)) {
+    const token = m[1];
+    if (!token || /^https?:/.test(token)) continue;
+    // join() (not resolve()) so a leading "/" is treated as a path segment,
+    // exactly like remark-includes' join(rootDir, includePath).
+    targets.add(resolve(join(versionRoot, token)));
+  }
+  return targets;
+}
+
+export class IncludeGraph {
+  constructor(versions) {
+    this.versions = versions;
+    // absFile -> Set<absTarget>
+    this.forward = new Map();
+    // absTarget -> Set<absFile that includes it>
+    this.reverse = new Map();
+    // absFile -> versionRoot (only for scanned source files)
+    this._versionRootOf = new Map();
+  }
+
+  // Which version's source tree does this file belong to (by path prefix)?
+  _versionRootForPath(absFile) {
+    for (const v of this.versions) {
+      if (absFile === v.source || absFile.startsWith(v.source + sep)) {
+        return v.root;
+      }
+    }
+    return null;
+  }
+
+  _removeEdges(absFile) {
+    const old = this.forward.get(absFile);
+    if (!old) return;
+    for (const t of old) {
+      const set = this.reverse.get(t);
+      if (set) {
+        set.delete(absFile);
+        if (set.size === 0) this.reverse.delete(t);
+      }
+    }
+    this.forward.delete(absFile);
+  }
+
+  _addEdges(absFile, versionRoot) {
+    const targets = scanFile(absFile, versionRoot);
+    this.forward.set(absFile, targets);
+    this._versionRootOf.set(absFile, versionRoot);
+    for (const t of targets) {
+      let set = this.reverse.get(t);
+      if (!set) this.reverse.set(t, (set = new Set()));
+      set.add(absFile);
+    }
+  }
+
+  // Full scan of every source .mdx across all versions.
+  build() {
+    const t0 = Date.now();
+    let files = 0;
+    for (const v of this.versions) {
+      for (const f of walkMdx(v.source)) {
+        this._addEdges(f, v.root);
+        files++;
+      }
+    }
+    return { files, edges: this.reverse.size, ms: Date.now() - t0 };
+  }
+
+  // Re-scan a single source file after it was created/edited.
+  update(absFile) {
+    const versionRoot = this._versionRootForPath(absFile);
+    if (!versionRoot) return;
+    this._removeEdges(absFile);
+    this._addEdges(absFile, versionRoot);
+  }
+
+  // Drop a source file that was deleted.
+  remove(absFile) {
+    this._removeEdges(absFile);
+    this._versionRootOf.delete(absFile);
+  }
+
+  // Given a changed target (an include or snippet file), return the set of
+  // PAGE files that must be re-emitted. Walks the reverse graph so nested
+  // includes (an include that includes the changed include) resolve correctly.
+  dependentPages(absTarget) {
+    const pages = new Set();
+    const seen = new Set();
+    const queue = [resolve(absTarget)];
+    while (queue.length) {
+      const node = queue.shift();
+      if (seen.has(node)) continue;
+      seen.add(node);
+      const includers = this.reverse.get(node);
+      if (!includers) continue;
+      for (const f of includers) {
+        // A real page (under docs/pages, not itself an include) is a leaf we
+        // emit. Anything else is an intermediate include; keep walking up.
+        if (isMdx(f) && !isInclude(f)) {
+          pages.add(f);
+        }
+        // Continue walking regardless, to support pages-including-pages and
+        // deeply nested include chains.
+        queue.push(f);
+      }
+    }
+    return pages;
+  }
+}

--- a/devtools/lib/log.mjs
+++ b/devtools/lib/log.mjs
@@ -1,0 +1,47 @@
+// Tiny logger with timestamps and levels. No dependencies.
+
+const COLOR = {
+  gray: "\x1b[90m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+  bold: "\x1b[1m",
+  reset: "\x1b[0m",
+};
+
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const paint = (c, s) => (useColor ? `${COLOR[c]}${s}${COLOR.reset}` : s);
+
+// A fixed-length clock so log lines align. Uses local time.
+const clock = () => {
+  const d = new Date();
+  const p = (n, w = 2) => String(n).padStart(w, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(
+    d.getMilliseconds(),
+    3,
+  )}`;
+};
+
+const tag = paint("cyan", "dev");
+
+let verbose = false;
+export const setVerbose = (v) => {
+  verbose = v;
+};
+
+const line = (mark, msg) =>
+  `${paint("gray", clock())} ${tag} ${mark} ${msg}`;
+
+export const log = {
+  info: (msg) => console.log(line(paint("green", "›"), msg)),
+  warn: (msg) => console.log(line(paint("yellow", "!"), paint("yellow", msg))),
+  error: (msg) => console.log(line(paint("red", "✗"), paint("red", msg))),
+  step: (msg) => console.log(line(paint("cyan", "•"), paint("bold", msg))),
+  debug: (msg) => {
+    if (verbose) console.log(line(paint("gray", "·"), paint("gray", msg)));
+  },
+  plain: (msg) => console.log(msg),
+};
+
+export { paint };

--- a/devtools/lib/process.mjs
+++ b/devtools/lib/process.mjs
@@ -1,0 +1,163 @@
+// Process lifecycle: preflight port/orphan cleanup, spawning the Docusaurus dev
+// server in its own process group, and reliably tearing the whole group down.
+//
+// This is the piece that fixes the "orphaned node holding port 3000 -> new tab
+// on 3001" failure mode of the old script, which killed only its direct shell
+// children and left the node grandchild running.
+
+import { spawn, spawnSync } from "node:child_process";
+import { writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./log.mjs";
+
+const PIDFILE = (root) => join(root, "devtools", ".dev.pid");
+
+// PIDs currently LISTENing on a TCP port (macOS/BSD lsof).
+export function pidsOnPort(port) {
+  const r = spawnSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0 || !r.stdout) return [];
+  return [...new Set(r.stdout.split(/\s+/).filter(Boolean).map(Number))];
+}
+
+// PIDs whose full command line matches a pattern (pgrep -f).
+function pgrep(pattern) {
+  const r = spawnSync("pgrep", ["-f", pattern], { encoding: "utf8" });
+  if (r.status !== 0 || !r.stdout) return [];
+  return r.stdout.split(/\s+/).filter(Boolean).map(Number);
+}
+
+const alive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+function killPid(pid, label) {
+  if (!pid || pid === process.pid || !alive(pid)) return false;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {}
+  // Escalate if still alive shortly after.
+  const deadline = Date.now() + 1500;
+  while (alive(pid) && Date.now() < deadline) {
+    spawnSync("sleep", ["0.05"]);
+  }
+  if (alive(pid)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+  if (label) log.warn(`reaped ${label} (pid ${pid})`);
+  return true;
+}
+
+// Free a specific port (kills whatever is LISTENing on it).
+export function freePort(port) {
+  const pids = pidsOnPort(port);
+  for (const pid of pids) killPid(pid, `process on :${port}`);
+  return pids.length;
+}
+
+// On startup: if a previous run of THIS tool left a pidfile, kill its server
+// group, then make sure the target port is free.
+export function reapOwn(root, port) {
+  const f = PIDFILE(root);
+  if (existsSync(f)) {
+    try {
+      const prev = JSON.parse(readFileSync(f, "utf8"));
+      if (prev.serverPid) {
+        try {
+          process.kill(-prev.serverPid, "SIGKILL");
+        } catch {}
+      }
+    } catch {}
+    rmSync(f, { force: true });
+  }
+  freePort(port);
+}
+
+// The "clean up the mess" button: aggressively kill every known docs dev process
+// for THIS repo — the legacy start-dev.sh watchers, stray docusaurus servers,
+// and any of our own sessions — then free the usual dev ports.
+export function reapAll(root, ports = [3000, 3001, 3002, 3003]) {
+  let n = 0;
+  const patterns = [
+    "scripts/start-dev.sh",
+    "watchexec .*--watch content",
+    `${root}/node_modules/.bin/docusaurus start`,
+    `${root}/node_modules/.bin/docusaurus`,
+    `${root}/devtools/dev.mjs`,
+  ];
+  const targets = new Set();
+  for (const p of patterns) for (const pid of pgrep(p)) targets.add(pid);
+  for (const pid of targets) if (killPid(pid, "legacy dev process")) n++;
+  for (const port of ports) n += freePort(port);
+  rmSync(PIDFILE(root), { force: true });
+  return n;
+}
+
+// Spawn `docusaurus start` in its own process group. Returns the child.
+//   devConfig — absolute path to an alternate config file (--config), used to
+//               apply the dev-only memory trims (see docusaurus.dev.config.ts).
+//   env       — extra env vars to layer on top of process.env (e.g. the
+//               DEV_ONLY_VERSIONS / NODE_OPTIONS knobs).
+export function spawnServer(root, { port, host, onReady, devConfig, env } = {}) {
+  const bin = join(root, "node_modules", ".bin", "docusaurus");
+  const args = ["start", "--no-open", "--port", String(port)];
+  if (host) args.push("--host", host);
+  if (devConfig) args.push("--config", devConfig);
+
+  const child = spawn(bin, args, {
+    cwd: root,
+    detached: true, // new process group => we can kill the whole tree
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(env || {}) },
+  });
+
+  let ready = false;
+  const scan = (buf, sink) => {
+    const s = buf.toString();
+    sink.write(s);
+    if (!ready && /(compiled|client.*compiled|running at|localhost:)/i.test(s)) {
+      ready = true;
+      onReady?.();
+    }
+  };
+  child.stdout.on("data", (b) => scan(b, process.stdout));
+  child.stderr.on("data", (b) => scan(b, process.stderr));
+
+  return child;
+}
+
+export function writePidfile(root, { serverPid, port }) {
+  writeFileSync(
+    PIDFILE(root),
+    JSON.stringify({ pid: process.pid, serverPid, port }),
+  );
+}
+
+export function removePidfile(root) {
+  rmSync(PIDFILE(root), { force: true });
+}
+
+// Kill the server's whole process group, escalating to SIGKILL.
+export function killServer(child) {
+  if (!child || child.killed || child.exitCode !== null) return;
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    try {
+      child.kill("SIGTERM");
+    } catch {}
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {}
+  }, 2000).unref?.();
+}

--- a/devtools/lib/sync.mjs
+++ b/devtools/lib/sync.mjs
@@ -1,0 +1,123 @@
+// Maps a changed file under content/<version>/ to the correct action against the
+// Docusaurus-visible tree (docs/, versioned_docs/, sidebars). All writes go to
+// generated (git-ignored) output, never back into content/, so there is no
+// feedback loop with the watcher.
+
+import {
+  copyFileSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
+import { resolve, relative, dirname, join, sep } from "node:path";
+
+const isMdx = (p) => p.endsWith(".mdx") || p.endsWith(".md");
+const isInclude = (p) => p.includes(`${sep}includes${sep}`);
+
+// Find the version whose source tree contains `abs`, plus the matching dest.
+function locate(abs, versions) {
+  for (const v of versions) {
+    if (abs === v.source || abs.startsWith(v.source + sep)) return v;
+  }
+  return null;
+}
+
+// Absolute destination file for a page source path.
+export function destForPage(abs, versions) {
+  const v = locate(abs, versions);
+  if (!v) return null;
+  const rel = relative(v.source, abs);
+  return join(v.dest, rel);
+}
+
+const ensureDir = (file) => {
+  const dir = dirname(file);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+};
+
+// Copy a page verbatim (matches prepare-files' copyFileSync fidelity).
+export function emitPage(abs, versions) {
+  const dest = destForPage(abs, versions);
+  if (!dest || !existsSync(abs)) return null;
+  ensureDir(dest);
+  copyFileSync(abs, dest);
+  return dest;
+}
+
+// Re-emit a page in a way that is GUARANTEED to change the destination bytes,
+// even when the source content is byte-identical (the case when only an included
+// partial changed). We toggle the number of trailing newlines, which is inert in
+// Markdown/MDX, so rspack's mtime+hash watcher always sees a real change and
+// recompiles — re-reading the fresh include.
+export function bumpPage(abs, versions) {
+  const dest = destForPage(abs, versions);
+  if (!dest || !existsSync(abs)) return null;
+  ensureDir(dest);
+  let out = readFileSync(abs, "utf8");
+  try {
+    if (readFileSync(dest, "utf8") === out) out += "\n";
+  } catch {
+    // dest missing — verbatim copy already differs from "nothing".
+  }
+  writeFileSync(dest, out);
+  return dest;
+}
+
+export function deletePage(abs, versions) {
+  const dest = destForPage(abs, versions);
+  if (!dest) return null;
+  rmSync(dest, { force: true });
+  return dest;
+}
+
+export function emitSidebar(abs, versions) {
+  const v = versions.find((v) => resolve(v.sidebarSource) === resolve(abs));
+  if (!v || !existsSync(abs)) return null;
+  ensureDir(v.sidebarDest);
+  copyFileSync(abs, v.sidebarDest);
+  return v.sidebarDest;
+}
+
+// Classify a changed absolute path into an action descriptor.
+//   { kind: "page"|"include", version, abs, exists }
+//   { kind: "sidebar", abs }
+//   { kind: "config", version, abs }
+//   { kind: "target", abs }        // possible non-mdx include target (examples/, CHANGELOG.md, ...)
+//   null                            // ignore
+export function classify(abs, versions) {
+  for (const v of versions) {
+    if (resolve(v.sidebarSource) === abs) return { kind: "sidebar", abs, version: v };
+    if (resolve(v.configSource) === abs) return { kind: "config", abs, version: v };
+  }
+  const v = locate(abs, versions);
+  if (v && isMdx(abs)) {
+    return {
+      kind: isInclude(abs) ? "include" : "page",
+      version: v,
+      abs,
+      exists: existsSync(abs),
+    };
+  }
+  // Anything else under a version root might be a non-mdx include target
+  // (a code snippet, CHANGELOG.md, ...). The caller checks the reverse graph.
+  for (const ver of versions) {
+    if (abs.startsWith(ver.root + sep)) return { kind: "target", abs, version: ver };
+  }
+  return null;
+}
+
+// Copy the repo-root tags.yml into every dest dir (prepare-files does this too).
+export function copyTags(root, versions) {
+  const src = join(root, "tags.yml");
+  if (!existsSync(src)) return [];
+  const written = [];
+  for (const v of versions) {
+    const dest = join(v.dest, "tags.yml");
+    ensureDir(dest);
+    copyFileSync(src, dest);
+    written.push(dest);
+  }
+  return written;
+}

--- a/devtools/lib/watcher.mjs
+++ b/devtools/lib/watcher.mjs
@@ -1,0 +1,60 @@
+// Thin wrapper over Node's native recursive fs.watch (FSEvents-backed on macOS).
+// Coalesces the bursts of events editors emit (atomic saves, multi-file saves)
+// into a single debounced batch of absolute paths handed to one callback.
+
+import { watch, existsSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./log.mjs";
+
+/**
+ * @param {Array<{dir: string, recursive?: boolean}>} specs Directories to watch.
+ * @param {(paths: string[]) => void} onBatch Called with a batch of absolute paths.
+ * @param {{debounceMs?: number}} [opts]
+ * @returns {() => void} close function
+ */
+export function watchPaths(specs, onBatch, { debounceMs = 80 } = {}) {
+  const pending = new Set();
+  let timer = null;
+  const watchers = [];
+
+  const flush = () => {
+    timer = null;
+    if (pending.size === 0) return;
+    const batch = [...pending];
+    pending.clear();
+    try {
+      onBatch(batch);
+    } catch (err) {
+      log.error(`watch handler error: ${err?.stack || err}`);
+    }
+  };
+
+  const enqueue = (abs) => {
+    pending.add(abs);
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(flush, debounceMs);
+  };
+
+  for (const { dir, recursive = true } of specs) {
+    if (!existsSync(dir)) continue;
+    try {
+      const w = watch(dir, { recursive }, (_eventType, filename) => {
+        if (!filename) return;
+        enqueue(join(dir, filename.toString()));
+      });
+      w.on("error", (err) => log.debug(`watch error on ${dir}: ${err}`));
+      watchers.push(w);
+    } catch (err) {
+      log.warn(`could not watch ${dir}: ${err?.message || err}`);
+    }
+  }
+
+  return () => {
+    if (timer) clearTimeout(timer);
+    for (const w of watchers) {
+      try {
+        w.close();
+      } catch {}
+    }
+  };
+}

--- a/devtools/selftest.mjs
+++ b/devtools/selftest.mjs
@@ -1,0 +1,118 @@
+// Read-only sanity checks for the dev tooling. Verifies that:
+//   1) the content -> docs/ + versioned_docs/ mapping matches what a real
+//      `yarn prepare-files` produced (compares a sample of emitted files), and
+//   2) the include-dependency graph resolves real partials to real dependents.
+//
+// Run: devtools/dev selftest      (safe; starts no server, writes nothing)
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { relative, join, sep } from "node:path";
+import { loadVersions } from "./lib/config.mjs";
+import { IncludeGraph } from "./lib/includes-graph.mjs";
+import { destForPage } from "./lib/sync.mjs";
+
+// Dependency-free sampler: first `n` real page .mdx files under sourceDir.
+function sampleMdxPages(sourceDir, n) {
+  const out = [];
+  const walk = (dir) => {
+    if (out.length >= n) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (out.length >= n) return;
+      const full = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === "includes") continue; // pages only
+        walk(full);
+      } else if (
+        e.isFile() &&
+        full.endsWith(".mdx") &&
+        !full.includes(`${sep}includes${sep}`)
+      ) {
+        out.push(full);
+      }
+    }
+  };
+  walk(sourceDir);
+  return out;
+}
+
+export function runSelftest(root) {
+  let ok = true;
+  const fail = (m) => {
+    ok = false;
+    console.log(`  ✗ ${m}`);
+  };
+  const pass = (m) => console.log(`  ✓ ${m}`);
+
+  const versions = loadVersions(root);
+  console.log(`versions: ${versions.map((v) => v.name).join(", ")}`);
+
+  // 1) Mapping check: pick a few real source pages per version and verify the
+  //    computed destination exists and is byte-identical (requires that
+  //    prepare-files has been run at least once).
+  for (const v of versions) {
+    if (!existsSync(v.source)) {
+      fail(`source missing for ${v.name}: ${relative(root, v.source)}`);
+      continue;
+    }
+    const samples = sampleMdxPages(v.source, 5);
+    if (samples.length === 0) {
+      fail(`no pages found under ${relative(root, v.source)}`);
+      continue;
+    }
+    let matched = 0;
+    for (const abs of samples) {
+      const dest = destForPage(abs, versions);
+      if (
+        dest &&
+        existsSync(dest) &&
+        readFileSync(dest).equals(readFileSync(abs))
+      ) {
+        matched++;
+      }
+    }
+    if (matched === samples.length) {
+      pass(
+        `${v.name}: ${matched}/${samples.length} sample pages map correctly → ${relative(root, v.dest)}/`,
+      );
+    } else {
+      fail(
+        `${v.name}: only ${matched}/${samples.length} sample pages match dest (run "yarn prepare-files" first?)`,
+      );
+    }
+    if (!existsSync(v.sidebarSource)) {
+      fail(`sidebar source missing: ${relative(root, v.sidebarSource)}`);
+    }
+  }
+
+  // 2) Include-graph check.
+  const graph = new IncludeGraph(versions);
+  const g = graph.build();
+  console.log(
+    `include graph: ${g.files} source files, ${g.edges} targets, ${g.ms}ms`,
+  );
+  if (g.files === 0) fail("graph found no source files");
+  if (g.edges === 0) fail("graph found no include targets — is the (!...!) scan working?");
+
+  // Confirm the reverse walk returns real page files for a few real partials.
+  let probed = 0;
+  for (const target of graph.reverse.keys()) {
+    if (probed >= 3) break;
+    if (!target.includes(`${sep}includes${sep}`)) continue;
+    const pages = graph.dependentPages(target);
+    if (pages.size > 0) {
+      probed++;
+      const ex = [...pages][0];
+      pass(`${relative(root, target)} ← ${pages.size} page(s) (e.g. ${relative(root, ex)})`);
+    }
+  }
+  if (probed === 0) fail("no include with resolvable dependent pages found");
+
+  console.log(ok ? "\nselftest: PASS" : "\nselftest: FAIL");
+  return ok;
+}


### PR DESCRIPTION
This is an improved `yarn dev`-style helper that:
- Reliably handles file changes without crashing when includes change
- Doesn't leave `docasaurus` processes running on close
- Selectively includes only specified versions (latest by default) to greatly reduce memory use.

While working on docs, I found that edit to an include file would put the existing `yarn dev` script into a restart loop, forcing it to copy files again from scratch, restart `docasaurus` on a new port due to a conflict, pop a new browser tab, and usually get stuck in a failed state. It also usually left zombie processes running.

I asked Claude to take a look at existing tooling to see if the bash
+ rsync situation could be merged into a proper tool, and this is what it came up with. It manages the `docasaurus` processes properly, and solves the include problem by maintaining its own include dependency graph and triggering specific copy/rerender operations without having to restart `docasaurus`.

Then, since I'm perpetually running out of memory on my MacBook, I also had it find some nonintrusive ways to reduce memory use from the default ~6 GiB. This (by default) disables sourcemaps and some debug features that aren't helpful when working on just Markdown, and only renders the latest version. These tweaks brought memory use down to ~2.6GiB on my machine.

As a note, this is totally vibe coded and should probably not be merged as-is, so I'm leaving it as a draft. Still, it's proven to be pretty robust for me so far and has been a nice improvement, so I figured it might be worth sharing. It doesn't modify the existing `docs-website` code at all and is safe to copy into your local clone without touching any real code. If desired, you can set up a local ignore in `.git/info/exclude` so it stays out of future commits.