### PR TITLE
Advertise Markdown alternates of docs pages to AI agents

### DIFF
--- a/src/theme/DocItem/Metadata/index.tsx
+++ b/src/theme/DocItem/Metadata/index.tsx
@@ -1,0 +1,31 @@
+import Head from "@docusaurus/Head";
+import { useLocation } from "@docusaurus/router";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { markdownAlternatePath } from "@site/src/utils/markdown";
+import Metadata from "@theme-original/DocItem/Metadata";
+import type { ReactNode } from "react";
+
+/**
+ * Wraps the default DocItem metadata to advertise the generated Markdown
+ * variant of each docs page. Every docs page has a corresponding .md file
+ * produced by the llms-txt plugin, so the tag renders on all doc routes
+ * (and only on doc routes). The href is relative so it resolves against
+ * whichever host serves the page (production, preview, or local).
+ */
+export default function MetadataWrapper(): ReactNode {
+  const { siteConfig } = useDocusaurusContext();
+  const { pathname } = useLocation();
+
+  return (
+    <>
+      <Metadata />
+      <Head>
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href={markdownAlternatePath(pathname, siteConfig.baseUrl)}
+        />
+      </Head>
+    </>
+  );
+}

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { markdownAlternatePath, normalizeMarkdownPathname } from "./markdown";
+
+describe("normalizeMarkdownPathname", () => {
+  it("returns /index.md for the root path", () => {
+    expect(normalizeMarkdownPathname("/")).toBe("/index.md");
+  });
+
+  it("replaces a trailing slash with .md", () => {
+    expect(normalizeMarkdownPathname("/core-concepts/")).toBe(
+      "/core-concepts.md",
+    );
+  });
+
+  it("appends .md when there is no trailing slash", () => {
+    expect(normalizeMarkdownPathname("/core-concepts")).toBe(
+      "/core-concepts.md",
+    );
+  });
+
+  it("handles nested and versioned paths", () => {
+    expect(normalizeMarkdownPathname("/get-started/agent-skills/")).toBe(
+      "/get-started/agent-skills.md",
+    );
+    expect(normalizeMarkdownPathname("/ver/17.x/core-concepts/")).toBe(
+      "/ver/17.x/core-concepts.md",
+    );
+  });
+});
+
+describe("markdownAlternatePath", () => {
+  it("normalizes a page pathname to its .md path", () => {
+    expect(markdownAlternatePath("/core-concepts/")).toBe("/core-concepts.md");
+  });
+
+  it("maps the root path to index.md", () => {
+    expect(markdownAlternatePath("/")).toBe("/index.md");
+  });
+
+  it("maps the site root under a baseUrl prefix to index.md", () => {
+    expect(markdownAlternatePath("/docs/", "/docs/")).toBe("/docs/index.md");
+    expect(markdownAlternatePath("/docs", "/docs/")).toBe("/docs/index.md");
+  });
+
+  it("leaves non-root pages under a baseUrl prefix unchanged", () => {
+    expect(markdownAlternatePath("/docs/installation/", "/docs/")).toBe(
+      "/docs/installation.md",
+    );
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -7,6 +7,19 @@ export const normalizeMarkdownPathname = (pathname: string) => {
   return `${pathname}.md`;
 };
 
+export const markdownAlternatePath = (
+  pathname: string,
+  baseUrl: string = "/",
+) => {
+  const root = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  // The site root under a baseUrl prefix (e.g. /docs/) maps to index.md
+  // rather than replacing the trailing slash (which would yield /docs.md).
+  if (pathname === root || pathname === root.slice(0, -1)) {
+    return `${root}index.md`;
+  }
+  return normalizeMarkdownPathname(pathname);
+};
+
 export const copyPageContentAsMarkdown = async (pathname: string) => {
   const normalizedPathname = normalizeMarkdownPathname(pathname);
 


### PR DESCRIPTION
We've implemented a number of changes to benefit agents in our docs, llms.txt, markdown pages, etc., but we haven't advertised to the agent that there is a markdown version of this page.

This PR adds a `<link rel="alternate" type="text/markdown" href="path-to-markdown-version">` tag to the head of every
docs page pointing to its Markdown version, so agents that parse the head can fetch the clean Markdown instead of the full page. 

Changes:

- Wrap-swizzle DocItem/Metadata to append the tag via @docusaurus/Head; the component only mounts on doc routes, so the tag renders exactly where a .md counterpart exists.
- Add markdownAlternateUrl() to src/utils/markdown.ts, joining siteConfig.url with the pathname normalized by the existing
  normalizeMarkdownPathname().
- Add unit tests covering root, trailing-slash, nested, and versioned paths plus URL joining.

The href follows siteConfig.url and the baseUrl-prefixed pathname, so production emits https://goteleport.com/docs/<page>.md , matching how the canonical and og:url tags already behave.

Links
https://acceptmarkdown.com/guides/accept-text-markdown#advertising-md-siblings-via-link--relalternate
https://keep.md/tools/markdown-for-agents