### PR TITLE
Move tokenx to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rehype-highlight": "^7.0.2",
     "remark-mdx": "^3.0.0",
     "remark-parse": "^11.0.0",
+    "tokenx": "^2.0.0",
     "unist-util-visit": "^5.1.0",
     "vite-node": "^6.0.0"
   },
@@ -119,7 +120,6 @@
     "remark-validate-links": "^11.0.2",
     "storybook": "^10.5.5",
     "to-vfile": "^8.0.0",
-    "tokenx": "^2.0.0",
     "ts-jest": "^29.4.12",
     "ts-loader": "^9.6.2",
     "tsc-esm-fix": "^3.1.0",


### PR DESCRIPTION
During conflict resolution in #700, this was mistakenly placed in `devDependencies`.