### PR TITLE
gha: stop using github secrets and vars contexts

### DIFF
--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -14,22 +14,31 @@ jobs:
     runs-on: ubuntu-22.04-2core-arm64
     environment: docs-amplify
     steps:
+    - name: Get runtime values from kvstore
+      id: kvstore
+      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
+      with:
+        cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+        cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+        values: |
+          IAM_ROLE,variable
+          AMPLIFY_APP_IDS,variable
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         aws-region: us-west-2
-        role-to-assume: ${{ vars.IAM_ROLE }}
+        role-to-assume: ${{ env.IAM_ROLE }}
 
     - name: Get Amplify Preview URL
       uses: gravitational/shared-workflows/tools/amplify-preview@986f92841a4f032e262477e5bb15f214d50b1015 # tools/amplify-preview/v0.0.6
       id: amplify_preview
       with:
-        app_ids: ${{ vars.AMPLIFY_APP_IDS }}
+        app_ids: ${{ env.AMPLIFY_APP_IDS }}
         create_branches: "false"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
         wait_interval: 60s
-
 
     - name: Print failure message
       if: failure()


### PR DESCRIPTION
Contributes to: https://github.com/gravitational/cloud/issues/14222, https://github.com/gravitational/cloud/issues/14690

This PR replaces usage of GitHub `{{ vars.* }}` with runtime values retrieved from the SOPS kvstore.
