### PR TITLE
Adding optional configuration for using preloaded docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Settings for AWS Amplify are following:
     - Target address: `/404.html`
     - Type `404 (Rewrite)`
 
+Production Amplify builds use a private ECR build image with Teleport docs content
+already staged under `/opt/docs-content/`. All Amplify builds will set the
+`DOCS_CONTENT_DIR` for example:
+
+```
+DOCS_CONTENT_DIR=/opt/docs-content
+```
+
+When `DOCS_CONTENT_DIR` is set, `yarn git-update` replaces the local `content/`
+contents with the preloaded image content and then exits successfully so
+`yarn build` can continue to `yarn prepare-files` and the Docusaurus build. The
+preloaded directory should contain the version folders expected by `config.json`,
+such as `content/17.x/docs`, `content/17.x/examples`, `content/18.x/docs`, and
+`content/19.x/docs` after it is copied into this repository.
+
 ## Architecture overview
 
 Current setup is made with the goal to make this project backward compatible with the original [docs engine](https://github.com/gravitational/docs) so they can run in parallel until transition period is not over.
@@ -71,7 +86,8 @@ To make it possible, we convert content from the orginal format to the Docusauru
 
 How it works under the hood:
 
-1. We store docs in the git submodules of the main `teleport` repo as in the original setup. Submodules are fetched inside `content` folder to the subfolders named after the teleport versions `15.x`, `16.x`, etc. Then we build the docs we update submodules to the latest version.
+1. We load docs into the `content` folder to the subfolders named after the teleport versions `17.x`, `18.x`, etc. Production Amplify builds use the preloaded content from `DOCS_CONTENT_DIR`. GitHub Actions and local development can 
+continue downloading GitHub archives as a fallback and local development can also optionally use git submodules.
 2. Info about versions, their status and original branches are manually added to the `config.json` file. See version config description below.
 3. To make old docs work with Ducsaurus we need to move files to correct location and also generate a bunch of config files. To do it we use `scripts/prepare-files.mts` file. It does the following based on `config.json` content:
     1. Move mdx files, except `includes` to the `versioned_docs/version-{name}` folder for the non-current versions.

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -6,10 +6,6 @@
 # no preloaded content is configured, CI and Amplify retrieve archives for the
 # latest release for each supported Teleport major version. Local development
 # uses git submodules.
-#
-# Note that, when checking docs content changes in gravitational/teleport, CI
-# jobs should clone the gravitational/teleport repository into a subdirectory of
-# content, rather than using this approach.
 DOCS_VERSIONS=$(jq -r '.versions[] | select(.deprecated != true) | .name' config.json);
 
 if [[ -n "${DOCS_CONTENT_DIR:-}" ]]; then
@@ -22,7 +18,10 @@ if [[ -n "${DOCS_CONTENT_DIR:-}" ]]; then
   # Clean out the content directory and copy the preloaded content into it.
   rm -rf content;
   mkdir content;
-  cp -a "${DOCS_CONTENT_DIR}/." content/;
+  if ! cp -a "${DOCS_CONTENT_DIR}/." content/; then
+    echo "Failed to copy docs content from DOCS_CONTENT_DIR.";
+    exit 1;
+  fi
 
   for v in $(echo "$DOCS_VERSIONS"); do
     if [[ ! -d "content/$v/docs" ]]; then

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -1,15 +1,41 @@
 #!/bin/bash
 
 
-# Load docs content into the content directory. In production or on CI runners,
-# retrieve archives for the latest release for each supported Teleport major
-# version. If running locally, use git submodules.
+# Load docs content into the content directory. When DOCS_CONTENT_DIR is set,
+# prefer content that has already been extracted into the build environment. If
+# no preloaded content is configured, CI and Amplify retrieve archives for the
+# latest release for each supported Teleport major version. Local development
+# uses git submodules.
 #
 # Note that, when checking docs content changes in gravitational/teleport, CI
 # jobs should clone the gravitational/teleport repository into a subdirectory of
 # content, rather than using this approach.
+DOCS_VERSIONS=$(jq -r '.versions[] | select(.deprecated != true) | .name' config.json);
+
+if [[ -n "${DOCS_CONTENT_DIR:-}" ]]; then
+  if [[ ! -d "${DOCS_CONTENT_DIR}" ]]; then
+    echo "DOCS_CONTENT_DIR is set to '${DOCS_CONTENT_DIR}', but that directory does not exist.";
+    exit 1;
+  fi
+
+  echo "Loading docs content from DOCS_CONTENT_DIR=${DOCS_CONTENT_DIR}";
+  # Clean out the content directory and copy the preloaded content into it.
+  rm -rf content;
+  mkdir content;
+  cp -a "${DOCS_CONTENT_DIR}/." content/;
+
+  for v in $(echo "$DOCS_VERSIONS"); do
+    if [[ ! -d "content/$v/docs" ]]; then
+      echo "Expected docs directory content/$v/docs was not found in DOCS_CONTENT_DIR.";
+      exit 1;
+    fi
+  done
+
+  echo "Docs content loaded from DOCS_CONTENT_DIR.";
+  exit 0;
+fi
+
 if [[ -n ${AWS_APP_ID} || -n ${CI} ]]; then
-  DOCS_VERSIONS=$(jq -r '.versions[] | select(.deprecated != true) | .name' config.json);
   for v in $(echo "$DOCS_VERSIONS"); do
      # Make sure there is a subdirectory in content for each version named in
      # config.json
@@ -22,4 +48,3 @@ if [[ -n ${AWS_APP_ID} || -n ${CI} ]]; then
 else
   git submodule update --init --remote --progress;
 fi
-


### PR DESCRIPTION
 Related to: gravitational/core#494

This change adds the ability for the build to pull from an optional staging location for content. This can be used to transfer docs content from our private repo by preloading a container image with the docs. The Amplify build will be configured to use the preloaded container image to build the docs.

```mermaid
flowchart LR
  publisher[Docs content publisher<br/>GitHub Actions] -->|builds docs content<br/>packages custom build image| ecr[(Private ECR<br/>teleport-docs-build-image)]

  ecr -->|Amplify pulls build image| amplify[AWS Amplify<br/>teleport-docs]

  docs[gravitational/docs-website] -->|source checkout| amplify

  amplify -->|yarn build<br/>DOCS_CONTENT_DIR=/opt/docs-content| site[Published docs site]

  publisher -. no direct access .- amplify

  classDef private fill:#f7f0ff,stroke:#7c3aed,color:#1f1235;
  classDef app fill:#eef6ff,stroke:#2563eb,color:#10233f;
  classDef repo fill:#f7f7f7,stroke:#555,color:#222;

  class ecr private;
  class amplify,site app;
  class publisher,docs repo;
```

This allows our Amplify build to not require secrets.