### PR TITLE
security: pin transitive uuid to 11.1.1 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,10 @@
   "resolutions": {
     "vfile": "^6.0.0",
     "vfile-message": "^4.0.0",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "@storybook/test-runner/uuid": "11.1.1",
+    "@storybook/test-runner/**/uuid": "11.1.1",
+    "**/sockjs/uuid": "11.1.1"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -18056,15 +18056,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
## Summary
Remediates [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (MEDIUM — uuid missing buffer bounds check in v3/v5/v6 when `buf` is provided). The vulnerable `uuid@8.3.2` is transitive, pulled via `@storybook/test-runner` (directly and through `jest-junit` and `nyc → istanbul-lib-processinfo`) and `@docusaurus/core → webpack-dev-server → sockjs`. The fix (11.1.1, published 2026-04-29) is out of range for their declared `^8.3.2`, and the latest releases of both parents still declare `^8.3.2`, so a resolution is the only path.

The resolutions are **path-scoped** (not a bare `"uuid"` key) so mermaid's safe `uuid@14.0.0` (via `@docusaurus/theme-mermaid`) is untouched — confirmed in `yarn.lock`.

## Verification
- `yarn.lock`: `uuid@^8.3.2` now resolves **11.1.1**; `uuid@^11.1.0 || ^12 || ^13 || ^14.0.0` still resolves 14.0.0 (unchanged).
- `yarn test`: 20/20 suites, 208/208 tests pass.
- (Local `yarn build` is unrelated-broken since #307 — relying on PR CI for the build path.)