### PR TITLE
Fix long redirect chain in footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -156,7 +156,7 @@ const config: Config = {
             },
             {
               label: "Downloads",
-              href: "https://goteleport.com/downloads/",
+              href: "https://goteleport.com/download/client-tools/",
             },
             {
               label: "Status",


### PR DESCRIPTION
Currently, the link to `/downloads/` in the footer leads to a five-step redirect chain:

- https://goteleport.com/downloads/
- https://goteleport.com/download
- https://goteleport.com/download/
- https://goteleport.com/download/client-tools
- https://goteleport.com/download/client-tools/

Use only the final step to improve SEO performance.